### PR TITLE
add "unbuffered" write mode to PX4 UART driver

### DIFF
--- a/Tools/scripts/parse_scanaplus.py
+++ b/Tools/scripts/parse_scanaplus.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+'''
+decode a Saleae logic CSV export file as PWM values. Used for
+testing output values on PWM channels
+'''
+
+import csv, sys
+import matplotlib.pyplot as plt
+import numpy as np;
+
+filename = sys.argv[1]
+
+c = open(filename, 'r')
+data = csv.reader(c,delimiter=';')
+
+pulse_start = []
+prev_values = []
+pwm = []
+nchannels = 0
+x = []
+y = []
+min_frame_interval = 1e6
+min_interval_t = 0
+
+for row in data:
+    # skip header
+    if row[0].startswith('Time'):
+        continue
+    changed = False
+
+    if len(row) > nchannels+1:
+        nchannels = len(row)-1
+        while len(pwm) < nchannels:
+            pwm.append(0)
+            pulse_start.append(0)
+            prev_values.append(0)
+
+    # time in seconds
+    tfields = row[0].split()
+    tval = float(''.join(tfields[:-1]))
+    units = tfields[-1]
+    if (units == 'us'):
+        t = tval * 1e-6
+    elif (units == 'ms'):
+        t = tval * 1e-3
+    elif (units == 's'):
+        t = tval
+
+    # current value of each channel
+    values = [int(row[i]) for i in range(1,len(row))]
+    
+    channelset = range(nchannels)
+    for c in channelset:
+        if values[c] == 1 and prev_values[c] == 0 and pulse_start[c] != 0:
+            low_interval = t - pulse_start[c] - pwm[c]
+            if (low_interval > 200e-6):
+                frame_interval = low_interval
+                if (frame_interval < min_frame_interval):
+                    min_frame_interval = frame_interval
+                    min_interval_t = t
+                    
+        if values[c] == 0 and prev_values[c] == 1 and pulse_start[c] != 0:
+            pulse = t - pulse_start[c]
+            if pulse < .003:
+                pwm[c] = pulse
+                changed = True
+        if values[c] == 1 and prev_values[c] == 0:
+            pulse_start[c] = t
+        prev_values[c] = values[c]
+        
+    if changed:
+        sys.stdout.write("%.7f" % t)
+        for c in channelset:
+            sys.stdout.write(" %.1f" % (1e6*pwm[c]))
+        sys.stdout.write("\n")
+            
+            
+        x.append(t)
+        y.append(pwm[1:nchannels])
+
+sys.stdout.write("min_frame_interval: %.6f at %.6f\n" % (min_frame_interval, min_interval_t))
+
+xa = np.array(x)
+ya = np.array(y)
+plt.figure(1)
+plt.plot(xa, ya)
+plt.grid()
+plt.show()
+

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -48,6 +48,11 @@ public:
     virtual void configure_parity(uint8_t v){};
     virtual void set_stop_bits(int n){};
 
+    /* unbuffered writes bypass the ringbuffer and go straight to the
+     * file descriptor
+     */
+    virtual bool set_unbuffered_writes(bool on){ return false; };
+
     /* Implementations of BetterStream virtual methods. These are
      * provided by AP_HAL to ensure consistency between ports to
      * different boards

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -28,7 +28,8 @@ PX4UARTDriver::PX4UARTDriver(const char *devpath, const char *perf_name) :
     _in_timer(false),
     _perf_uart(perf_alloc(PC_ELAPSED, perf_name)),
     _os_start_auto_space(-1),
-    _flow_control(FLOW_CONTROL_DISABLE)
+    _flow_control(FLOW_CONTROL_DISABLE),
+    _unbuffered_writes(false)
 {
 }
 
@@ -184,6 +185,11 @@ void PX4UARTDriver::set_stop_bits(int n) {
     if (n > 1) t.c_cflag |= CSTOPB;
     else t.c_cflag &= ~CSTOPB;
     tcsetattr(_fd, TCSANOW, &t);
+}
+
+bool PX4UARTDriver::set_unbuffered_writes(bool on) {
+    _unbuffered_writes = on;
+    return _unbuffered_writes;
 }
 
 void PX4UARTDriver::begin(uint32_t b)

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -307,6 +307,11 @@ size_t PX4UARTDriver::write(uint8_t c)
         return 0;
     }
 
+    if (_unbuffered_writes) {
+        // write one byte to the file descriptor
+        return _write_fd(&c, 1);
+    }
+
     while (_writebuf.space() == 0) {
         if (_nonblocking_writes) {
             return 0;
@@ -329,9 +334,9 @@ size_t PX4UARTDriver::write(const uint8_t *buffer, size_t size)
 		return 0;
 	}
 
-    if (!_nonblocking_writes) {
+    if (!_nonblocking_writes || _unbuffered_writes) {
         /*
-          use the per-byte delay loop in write() above for blocking writes
+          use the per-byte delay loop in write() above for blocking and unbuffered writes
          */
         size_t ret = 0;
         while (size--) {

--- a/libraries/AP_HAL_PX4/UARTDriver.cpp
+++ b/libraries/AP_HAL_PX4/UARTDriver.cpp
@@ -334,7 +334,7 @@ size_t PX4UARTDriver::write(const uint8_t *buffer, size_t size)
 		return 0;
 	}
 
-    if (!_nonblocking_writes || _unbuffered_writes) {
+    if (!_nonblocking_writes) {
         /*
           use the per-byte delay loop in write() above for blocking and unbuffered writes
          */
@@ -346,7 +346,12 @@ size_t PX4UARTDriver::write(const uint8_t *buffer, size_t size)
         return ret;
     }
 
-    return _writebuf.write(buffer, size);
+    if (_unbuffered_writes) {
+        // write buffer straight to the file descriptor
+        return _write_fd(buffer, size);
+    } else {
+        return _writebuf.write(buffer, size);
+    }
 }
 
 /*

--- a/libraries/AP_HAL_PX4/UARTDriver.h
+++ b/libraries/AP_HAL_PX4/UARTDriver.h
@@ -41,6 +41,7 @@ public:
 
     void configure_parity(uint8_t v);
     void set_stop_bits(int n);
+    bool set_unbuffered_writes(bool on);
 
 private:
     const char *_devpath;
@@ -50,6 +51,7 @@ private:
     volatile bool _in_timer;
 
     bool _nonblocking_writes;
+    bool _unbuffered_writes;
 
     // we use in-task ring buffers to reduce the system call cost
     // of ::read() and ::write() in the main loop


### PR DESCRIPTION
@tridge uses _writefd method to write single bytes directly to the file descriptor
with sbus_frame_interval at 3msec, minimum interframe gap observed over 10 seconds is 951 usec
