### PR TITLE
AP_MotorsMatrixTS refactor

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -424,6 +424,7 @@ private:
         AP_Float vectored_hover_power;
         AP_Float throttle_scale_max;
         AP_Float max_roll_angle;
+        AP_Int16 motor_mask;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -213,6 +213,19 @@ void QuadPlane::tailsitter_speed_scaling(void)
         scaling = constrain_float(hover_throttle / throttle, 0, tailsitter.throttle_scale_max);
     }
     
+    // reduce throws if in VTOL mode at large pitch angles (implies high airspeed)
+    const float magic_attenuation = 0.5f;
+    const float magic_roll_thresh = 30.0f;
+    if (in_vtol_mode()) {
+        float roll = labs(ahrs_view->roll_sensor) / 100.0f;
+        float pitch = labs(ahrs_view->pitch_sensor) / 100.0f;
+        if (pitch > tailsitter.transition_angle) {
+            scaling = constrain_float(magic_attenuation * (float)(tailsitter.transition_angle) / pitch, 0.25f, 1.0f);
+        }
+        else if (roll > 30) {
+            scaling = constrain_float(magic_attenuation * magic_roll_thresh / roll, 0.25f, 1.0f);
+        }
+    }
     const SRV_Channel::Aux_servo_function_t functions[4] = {
         SRV_Channel::Aux_servo_function_t::k_aileron,
         SRV_Channel::Aux_servo_function_t::k_elevator,

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -559,6 +559,7 @@ void AC_AttitudeControl::attitude_controller_run_quat()
     Quaternion desired_ang_vel_quat = to_to_from_quat.inverse()*attitude_target_ang_vel_quat*to_to_from_quat;
 
     // Correct the thrust vector and smoothly add feedforward and yaw input
+    // prioritize roll/pitch over yaw when _thrust_error_angle is large
     if(_thrust_error_angle > AC_ATTITUDE_THRUST_ERROR_ANGLE*2.0f){
         _rate_target_ang_vel.z = _ahrs.get_gyro().z;
     }else if(_thrust_error_angle > AC_ATTITUDE_THRUST_ERROR_ANGLE){

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -26,7 +26,8 @@
 #define AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX          1.0f    // body-frame rate controller maximum output (for roll-pitch axis)
 #define AC_ATTITUDE_RATE_YAW_CONTROLLER_OUT_MAX         1.0f    // body-frame rate controller maximum output (for yaw axis)
 
-#define AC_ATTITUDE_THRUST_ERROR_ANGLE                  radians(30.0f) // Thrust angle error above which yaw corrections are limited
+// disable yaw rate setpoint unlocking with error angle limit of 180 degrees
+#define AC_ATTITUDE_THRUST_ERROR_ANGLE                  radians(180.0f) // Thrust angle error above which yaw corrections are limited
 
 #define AC_ATTITUDE_400HZ_DT                            0.0025f // delta time in seconds for 400hz update rate
 

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -11,3 +11,4 @@
 #include "AP_MotorsCoax.h"
 #include "AP_MotorsTailsitter.h"
 #include "AP_Motors6DOF.h"
+#include "AP_MotorsMatrixTS.h"

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.cpp
@@ -1,0 +1,115 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *       AP_MotorsMatrixTS.cpp - tailsitters with multicopter motor configuration
+ */
+
+#include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_HAL/AP_HAL.h>
+#include "AP_MotorsMatrixTS.h"
+
+extern const AP_HAL::HAL& hal;
+
+#define SERVO_OUTPUT_RANGE  4500
+
+void AP_MotorsMatrixTS::output_fixed_wing(bool vtrans, float vectored_forward_gain, uint16_t mask) {
+
+    // control thrust vectoring in fixed wing flight
+    // Inputs are roll and pitch demands
+    float elevator = SRV_Channels::get_output_scaled(SRV_Channel::k_elevator);
+
+    // differential thrust on pitch and yaw axis for quad tailsitter
+    // Must suppress this if not armed
+    if (hal.util->get_soft_armed()) {
+        // normalize throttle to [0, 1]
+        float throttle;
+        if (vtrans) {
+             throttle = get_throttle_hover();
+        } else {
+             throttle = .01f * SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
+        }
+        // normalize elevator and rudder to range [-1.00,1.00] by dividing by 4500
+        float rudder = SRV_Channels::get_output_scaled(SRV_Channel::k_rudder);
+        float elev_diff = vectored_forward_gain * elevator * (1.0f / 4500.0f);
+        float rudd_diff = vectored_forward_gain * rudder * (1.0f / 4500.0f);
+
+        // probably need a pitch trim offset for motors with nonzero pitch_factor
+        for (int i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+            if (motor_enabled[i]) {
+                // shut down motors not enabled for FW flight
+                float thrust = 0.0f;
+                if ((1U<<i) & mask) {
+                    thrust = throttle + elev_diff * _pitch_factor[i] +
+                                        rudd_diff * _roll_factor[i];
+                }
+                int16_t motor_out = calc_thrust_to_pwm(thrust);
+                rc_write(i, motor_out);
+            }
+        }
+    }
+}
+
+void AP_MotorsMatrixTS::output_to_motors()
+{
+    // calls calc_thrust_to_pwm(_thrust_rpyt_out[i]) for each enabled motor
+    AP_MotorsMatrix::output_to_motors();
+
+    // also actuate control surfaces
+    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron,  -_yaw_in * SERVO_OUTPUT_RANGE);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, _pitch_in * SERVO_OUTPUT_RANGE);
+}
+
+void AP_MotorsMatrixTS::output_armed_stabilizing()
+{
+    // calculates thrust values _thrust_rpyt_out
+    AP_MotorsMatrix::output_armed_stabilizing();
+}
+
+void AP_MotorsMatrixTS::setup_motors(motor_frame_class frame_class, motor_frame_type frame_type)
+{
+    // remove existing motors
+    for (int8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        remove_motor(i);
+    }
+
+    bool success = false;
+
+    switch (frame_class) {
+
+        case MOTOR_FRAME_TS_QUAD:
+            switch (frame_type) {
+                case MOTOR_FRAME_TYPE_PLUS:
+                    add_motor(AP_MOTORS_MOT_1,  90, 0, 2);
+                    add_motor(AP_MOTORS_MOT_2, -90, 0, 4);
+                    add_motor(AP_MOTORS_MOT_3,   0, 0,  1);
+                    add_motor(AP_MOTORS_MOT_4, 180, 0,  3);
+                    success = true;
+                    break;
+                default:
+                    // matrixTS doesn't support the configured frame_type
+                    break;
+            }
+
+        default:
+            // matrixTS doesn't support the configured frame_class
+            break;
+        } // switch frame_class
+
+    // normalise factors to magnitude 0.5
+    normalise_rpy_factors();
+
+    _flags.initialised_ok = success;
+}

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.h
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.h
@@ -1,0 +1,30 @@
+/// @file	AP_MotorsMatrixTS.h
+/// @brief	Motor control class for tailsitters with multicopter motor configurations
+
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
+#include <SRV_Channel/SRV_Channel.h>
+#include "AP_MotorsMatrix.h"
+
+/// @class      AP_MotorsMatrix
+class AP_MotorsMatrixTS : public AP_MotorsMatrix {
+public:
+
+    AP_MotorsMatrixTS(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_MotorsMatrix(loop_rate, speed_hz) {
+        AP_Param::setup_object_defaults(this, var_info);
+    };
+
+    virtual void        output_to_motors() override;
+
+    virtual void output_fixed_wing(bool vtrans, float vectored_forward_gain, uint16_t mask) override;
+
+protected:
+    // configures the motors for the defined frame_class and frame_type
+    virtual void        setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override;
+
+    // calculate motor outputs
+    void                output_armed_stabilizing() override;
+};

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -88,6 +88,8 @@ public:
         _thrust_compensation_callback = callback;
     }
     
+    virtual void output_fixed_wing(bool vtrans, float vectored_forward_gain, uint16_t mask) {};
+
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo        var_info[];
 

--- a/libraries/AP_Motors/AP_MotorsTailsitter.cpp
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.cpp
@@ -52,7 +52,6 @@ void AP_MotorsTailsitter::init(motor_frame_class frame_class, motor_frame_type f
     // left servo defaults to servo output 4
     SRV_Channels::set_aux_channel_default(SRV_Channel::k_tiltMotorLeft, CH_4);
     SRV_Channels::set_angle(SRV_Channel::k_tiltMotorLeft, SERVO_OUTPUT_RANGE);
-
     // record successful initialisation if what we setup was the desired frame_class
     _flags.initialised_ok = (frame_class == MOTOR_FRAME_TAILSITTER);
 }
@@ -71,7 +70,6 @@ void AP_MotorsTailsitter::set_update_rate(uint16_t speed_hz)
 {
     // record requested speed
     _speed_hz = speed_hz;
-
     SRV_Channels::set_rc_frequency(SRV_Channel::k_throttleLeft, speed_hz);
     SRV_Channels::set_rc_frequency(SRV_Channel::k_throttleRight, speed_hz);
 }
@@ -82,7 +80,7 @@ void AP_MotorsTailsitter::output_to_motors()
         return;
     }
     float throttle_pwm = 0.0f;
-
+    
     switch (_spool_mode) {
         case SHUT_DOWN:
             throttle_pwm = get_pwm_output_min();
@@ -101,8 +99,7 @@ void AP_MotorsTailsitter::output_to_motors()
             SRV_Channels::set_output_pwm(SRV_Channel::k_throttleLeft, calc_thrust_to_pwm(_thrust_left));
             SRV_Channels::set_output_pwm(SRV_Channel::k_throttleRight, calc_thrust_to_pwm(_thrust_right));
             break;
-    }
-
+        }
     // Always output to tilt servos
     SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, _tilt_left*SERVO_OUTPUT_RANGE);
     SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, _tilt_right*SERVO_OUTPUT_RANGE);
@@ -170,7 +167,7 @@ void AP_MotorsTailsitter::output_armed_stabilizing()
         thr_adj = 1.0f - thrust_max;
         limit.throttle_upper = true;
         limit.roll_pitch = true;
-    }
+}
 
     // Add adjustment to reduce average throttle
     _thrust_left  = constrain_float(_thrust_left  + thr_adj, 0.0f, 1.0f);

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -17,6 +17,7 @@ public:
     // init
     void init(motor_frame_class frame_class, motor_frame_type frame_type) override;
 
+    // *** note that the following 2 methods are empty => frame_type and speed_hz are ignored ***
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
     void set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) override {}
 

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -44,6 +44,9 @@ public:
         MOTOR_FRAME_HELI_DUAL = 11,
         MOTOR_FRAME_DODECAHEXA = 12,
         MOTOR_FRAME_HELI_QUAD = 13,
+        // MotorsMatrix based non-vectored tailsitters
+        MOTOR_FRAME_TS_QUAD = 14,
+        MOTOR_FRAME_TS_HEXA = 15
     };
     enum motor_frame_type {
         MOTOR_FRAME_TYPE_PLUS = 0,

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -143,6 +143,8 @@ public:
         k_scripting14           = 107,
         k_scripting15           = 108,
         k_scripting16           = 109,
+        k_throttleTop           = 110,
+        k_throttleBot           = 111,
         k_nr_aux_servo_functions         ///< This must be the last enum value (only add new values _before_ this one)
     } Aux_servo_function_t;
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -119,6 +119,10 @@ void SRV_Channel::aux_servo_function_setup(void)
     case k_throttle:
     case k_throttleLeft:
     case k_throttleRight:
+    case k_motor1:
+    case k_motor2:
+    case k_motor3:
+    case k_motor4:
         // fixed wing throttle
         set_range(100);
         break;


### PR DESCRIPTION
FW mode motor handling moved from tailsitter_output to new public method output_fixed_wing() in AP_MotorsMatrixMulticopter::and using MotorsMatrix roll_pitch_factor values for thrust vectoring.

Currently borrows parameters from tiltrotor: Q_TILT_MASK to specify motors to be used in forward flight and Q_TAILSIT_VFGAIN to control differential thrust. 