### PR TITLE
ArduPlane: add QACRO mode for tailsitters

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -679,7 +679,7 @@ void Plane::update_flight_mode(void)
 
         break;
     }
-        
+    case QACRO:
     case INITIALISING:
         // handled elsewhere
         break;
@@ -775,6 +775,7 @@ void Plane::update_navigation()
     case QLAND:
     case QRTL:
     case QAUTOTUNE:
+    case QACRO:
         // nothing to do
         break;
     }

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -155,6 +155,7 @@ void Plane::stabilize_stick_mixing_direct()
         control_mode == QLOITER ||
         control_mode == QLAND ||
         control_mode == QRTL ||
+        control_mode == QACRO ||
         control_mode == TRAINING ||
         control_mode == QAUTOTUNE) {
         return;
@@ -185,6 +186,7 @@ void Plane::stabilize_stick_mixing_fbw()
         control_mode == QLOITER ||
         control_mode == QLAND ||
         control_mode == QRTL ||
+        control_mode == QACRO ||
         control_mode == TRAINING ||
         control_mode == QAUTOTUNE ||
         (control_mode == AUTO && g.auto_fbw_steer == 42)) {
@@ -396,6 +398,7 @@ void Plane::stabilize()
                 control_mode == QLOITER ||
                 control_mode == QLAND ||
                 control_mode == QRTL ||
+                control_mode == QACRO ||
                 control_mode == QAUTOTUNE) &&
                !quadplane.in_tailsitter_vtol_transition()) {
         quadplane.control_run();

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -23,6 +23,7 @@ MAV_MODE GCS_MAVLINK_Plane::base_mode() const
     case MANUAL:
     case TRAINING:
     case ACRO:
+    case QACRO:
         _base_mode = MAV_MODE_FLAG_MANUAL_INPUT_ENABLED;
         break;
     case STABILIZE:

--- a/ArduPlane/GCS_Plane.cpp
+++ b/ArduPlane/GCS_Plane.cpp
@@ -77,6 +77,7 @@ void GCS_Plane::update_sensor_status_flags(void)
         break;
 
     case ACRO:
+    case QACRO:
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL; // 3D angular rate control
         break;
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -66,7 +66,8 @@ enum FlightMode {
     QLOITER       = 19,
     QLAND         = 20,
     QRTL          = 21,
-    QAUTOTUNE	  = 22
+    QAUTOTUNE     = 22,
+    QACRO         = 23,
 };
 
 enum mode_reason_t {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1808,10 +1808,17 @@ void QuadPlane::control_run(void)
     default:
         break;
     }
+
     // we also stabilize using fixed wing surfaces
-    float speed_scaler = plane.get_speed_scaler();
-    plane.stabilize_roll(speed_scaler);
-    plane.stabilize_pitch(speed_scaler);
+    if (tailsitter.motor_mask == 0) {
+        float speed_scaler = plane.get_speed_scaler();
+        plane.stabilize_roll(speed_scaler);
+        plane.stabilize_pitch(speed_scaler);
+    } else {
+        // nothing to do here:
+        // copter tailsitters use AP_MotorsMatrixTS which actuates
+        // any fixed-wing control surfaces using the copter attitude controller
+    }
 }
 
 /*

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -821,6 +821,16 @@ void QuadPlane::check_attitude_relax(void)
     last_att_control_ms = now;
 }
 
+/*
+  init QACRO mode
+ */
+void QuadPlane::init_qacro(void)
+{
+    throttle_wait = false;
+    transition_state = TRANSITION_DONE;
+    attitude_control->relax_attitude_controllers();
+}
+
 // init quadplane hover mode 
 void QuadPlane::init_hover(void)
 {
@@ -870,6 +880,67 @@ void QuadPlane::hold_hover(float target_climb_rate)
     // call position controller
     pos_control->set_alt_target_from_climb_rate_ff(target_climb_rate, plane.G_Dt, false);
     run_z_controller();
+}
+
+/*
+  control QACRO mode
+ */
+void QuadPlane::control_qacro(void)
+{
+    if (throttle_wait) {
+        motors->set_desired_spool_state(AP_Motors::DESIRED_GROUND_IDLE);
+        attitude_control->set_throttle_out_unstabilized(0, true, 0);
+    } else {
+        check_attitude_relax();
+
+        motors->set_desired_spool_state(AP_Motors::DESIRED_THROTTLE_UNLIMITED);
+
+        // convert the input to the desired body frame rate
+        // Note that the 90 degree Y rotation for copter mode swaps roll and yaw
+        float roll_in = plane.channel_rudder->norm_input();
+        float pitch_in = plane.channel_pitch->norm_input();
+        float yaw_in = -plane.channel_roll->norm_input();
+
+        // acro_roll_rate param applies to yaw in copter frame
+        float target_roll = roll_in * 90 * 100.0f;
+        float target_pitch = pitch_in * plane.g.acro_pitch_rate * 100.0f;
+        float target_yaw = yaw_in * plane.g.acro_roll_rate * 100.0f;
+
+        // get pilot's desired throttle
+        int16_t mid_stick = plane.channel_throttle->get_control_mid();
+        // protect against unlikely divide by zero
+        if (mid_stick <= 0) {
+            mid_stick = 50;
+        }
+        float thr_mid = motors->get_throttle_hover();
+        int16_t throttle_control = plane.channel_throttle->get_control_in();
+        float throttle_in;
+        if (throttle_control < mid_stick) {
+            // below the deadband
+            throttle_in = ((float)throttle_control) * 0.5f / (float)mid_stick;
+        } else if (throttle_control > mid_stick) {
+            // above the deadband
+            throttle_in = 0.5f + ((float)(throttle_control - mid_stick)) * 0.5f / (float)(100 - mid_stick);
+        } else {
+            // must be in the deadband
+            throttle_in = 0.5f;
+        }
+
+        float expo = constrain_float(-(thr_mid - 0.5) / 0.375, -0.5f, 1.0f);
+        // calculate the output throttle using the given expo function
+        float throttle_out = throttle_in*(1.0f-expo) + expo*throttle_in*throttle_in*throttle_in;
+
+        // run attitude controller
+        if (plane.g.acro_locking) {
+            attitude_control->input_rate_bf_roll_pitch_yaw(target_roll, target_pitch, target_yaw);
+        } else {
+            attitude_control->input_rate_bf_roll_pitch_yaw_2(target_roll, target_pitch, target_yaw);
+            attitude_control->attitude_controller_run_quat();
+        }
+
+        // output pilot's throttle without angle boost
+        attitude_control->set_throttle_out(throttle_out, false, 10.0f);
+    }
 }
 
 /*
@@ -964,6 +1035,9 @@ bool QuadPlane::is_flying_vtol(void) const
     }
     if (motors->get_throttle() > 0.01f) {
         // if we are demanding more than 1% throttle then don't consider aircraft landed
+        return true;
+    }
+    if (plane.control_mode == QACRO) {
         return true;
     }
     if (plane.control_mode == GUIDED && guided_takeoff) {
@@ -1710,6 +1784,9 @@ void QuadPlane::control_run(void)
     }
 
     switch (plane.control_mode) {
+    case QACRO:
+        control_qacro();
+        break;
     case QSTABILIZE:
         control_stabilize();
         break;
@@ -1775,6 +1852,9 @@ bool QuadPlane::init_mode(void)
     case QAUTOTUNE:
         return qautotune.init();
 #endif
+    case QACRO:
+        init_qacro();
+        break;
     default:
         break;
     }
@@ -1864,6 +1944,7 @@ bool QuadPlane::in_vtol_mode(void) const
             plane.control_mode == QLOITER ||
             plane.control_mode == QLAND ||
             plane.control_mode == QRTL ||
+            plane.control_mode == QACRO ||
             plane.control_mode == QAUTOTUNE ||
             ((plane.control_mode == GUIDED || plane.control_mode == AVOID_ADSB) && plane.auto_state.vtol_loiter) ||
             in_vtol_auto());

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -196,6 +196,8 @@ private:
     void control_stabilize(void);
 
     void check_attitude_relax(void);
+    void init_qacro(void);
+    void control_qacro(void);
     void init_hover(void);
     void control_hover(void);
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -233,6 +233,8 @@ private:
 
     // calculate a stopping distance for fixed-wing to vtol transitions
     float stopping_distance(void);
+
+    void log_CTHP(float, bool);
     
     AP_Int16 transition_time_ms;
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -428,6 +428,7 @@ private:
         AP_Float vectored_hover_power;
         AP_Float throttle_scale_max;
         AP_Float max_roll_angle;
+        AP_Int16 motor_mask;
     } tailsitter;
 
     // the attitude view of the VTOL attitude controller

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -473,6 +473,7 @@ void Plane::set_mode(enum FlightMode mode, mode_reason_t reason)
     case QLAND:
     case QRTL:
     case QAUTOTUNE:
+    case QACRO:
         throttle_allows_nudging = true;
         auto_navigation_mode = false;
         if (!quadplane.init_mode()) {

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -14,6 +14,8 @@
  */
 /*
   control code for tailsitters. Enabled by setting Q_FRAME_CLASS=10 
+  or by setting Q_TAILSIT_MOTMX nonzero and Q_FRAME_CLASS and Q_FRAME_TYPE
+  to a configuration supported by AP_MotorsMatrix
  */
 
 #include "Plane.h"
@@ -23,7 +25,8 @@
  */
 bool QuadPlane::is_tailsitter(void) const
 {
-    return available() && frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER;
+    return available() && ((frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER) || 
+                           (tailsitter.motor_mask != 0));
 }
 
 /*
@@ -55,8 +58,11 @@ void QuadPlane::tailsitter_output(void)
 
     float tilt_left = 0.0f;
     float tilt_right = 0.0f;
+    uint16_t mask = tailsitter.motor_mask;
 
+    // handle forward flight modes and transition to VTOL modes
     if (!tailsitter_active() || in_tailsitter_vtol_transition()) {
+        // in forward flight: set motor tilt servos and throttles using FW controller
         if (tailsitter.vectored_forward_gain > 0) {
             // thrust vectoring in fixed wing flight
             float aileron = SRV_Channels::get_output_scaled(SRV_Channel::k_aileron);
@@ -66,23 +72,38 @@ void QuadPlane::tailsitter_output(void)
         }
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorLeft, tilt_left);
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRight, tilt_right);
-        
-        if (in_tailsitter_vtol_transition() && !throttle_wait && is_flying() && hal.util->get_soft_armed()) {
+
+        // get FW controller throttle demand and mask of motors enabled during forward flight
+        float throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle);
+        if (hal.util->get_soft_armed()) {
+            if (in_tailsitter_vtol_transition() && !throttle_wait && is_flying()) {
             /*
-              during transitions to vtol mode set the throttle to the
-              hover throttle, and set the altitude controller
+              during transitions to vtol mode set the throttle to
+              hover thrust, center the rudder and set the altitude controller
               integrator to the same throttle level
              */
-            uint8_t throttle = motors->get_throttle_hover() * 100;
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
-            SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);
+            throttle = motors->get_throttle_hover() * 100;
             SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
             pos_control->get_accel_z_pid().set_integrator(throttle*10);
+            
+            if (mask == 0) {
+                // override AP_MotorsTailsitter throttles during back transition
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);            
+            }
+        }
+        if (mask != 0) {
+            // set AP_MotorsMatrix throttles enabled for forward flight
+            motors->output_motor_mask(throttle * 0.01f, mask, plane.rudder_dt);
+            }
         }
         return;
     }
     
+    // handle VTOL modes
+    // the MultiCopter rate controller has already been run in an earlier call 
+    // to motors_output() from quadplane.update()
     motors_output(false);
     plane.pitchController.reset_I();
     plane.rollController.reset_I();
@@ -218,6 +239,18 @@ void QuadPlane::tailsitter_speed_scaling(void)
         scaling = constrain_float(hover_throttle / throttle, 0, tailsitter.throttle_scale_max);
     }
 
+    // if no airspeed sensor reduce throws at large tilt angles (implies high airspeed)
+    if (!ahrs.airspeed_sensor_enabled()) {
+        // ramp down from 1 to max_atten at tilt angles from 45 to 80 degrees
+        constexpr float max_atten = 0.25f;
+        constexpr float c_trans_angle = cosf(M_PI_4);
+        constexpr float alpha = (1 - max_atten) / (c_trans_angle - cosf(radians(80)));
+        constexpr float beta = 1 - alpha * c_trans_angle;
+        const float c_tilt = ahrs_view->get_rotation_body_to_ned().c.z;
+        if (c_tilt < c_trans_angle) {
+            scaling = constrain_float(beta + alpha * c_tilt, max_atten, 1.0f);
+        }
+    }
     const SRV_Channel::Aux_servo_function_t functions[4] = {
         SRV_Channel::Aux_servo_function_t::k_aileron,
         SRV_Channel::Aux_servo_function_t::k_elevator,

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -13,19 +13,23 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /*
-  control code for tailsitters. Enabled by setting Q_FRAME_CLASS=10 
+  control code for tailsitters. Enabled by setting Q_FRAME_CLASS=10
   or by setting Q_TAILSIT_MOTMX nonzero and Q_FRAME_CLASS and Q_FRAME_TYPE
   to a configuration supported by AP_MotorsMatrix
  */
 
+#include <math.h>
+
 #include "Plane.h"
+
+#define DEBUG_SPEED_SCALING 1
 
 /*
   return true when flying a tailsitter
  */
 bool QuadPlane::is_tailsitter(void) const
 {
-    return available() && ((frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER) || 
+    return available() && ((frame_class == AP_Motors::MOTOR_FRAME_TAILSITTER) ||
                            (tailsitter.motor_mask != 0));
 }
 
@@ -85,12 +89,12 @@ void QuadPlane::tailsitter_output(void)
             throttle = motors->get_throttle_hover() * 100;
             SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, 0);
             pos_control->get_accel_z_pid().set_integrator(throttle*10);
-            
+
             if (mask == 0) {
                 // override AP_MotorsTailsitter throttles during back transition
                 SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle);
                 SRV_Channels::set_output_scaled(SRV_Channel::k_throttleLeft, throttle);
-                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);            
+                SRV_Channels::set_output_scaled(SRV_Channel::k_throttleRight, throttle);
             }
         }
         if (mask != 0) {
@@ -100,9 +104,9 @@ void QuadPlane::tailsitter_output(void)
         }
         return;
     }
-    
+
     // handle VTOL modes
-    // the MultiCopter rate controller has already been run in an earlier call 
+    // the MultiCopter rate controller has already been run in an earlier call
     // to motors_output() from quadplane.update()
     motors_output(false);
     plane.pitchController.reset_I();
@@ -221,47 +225,149 @@ void QuadPlane::tailsitter_check_input(void)
 }
 
 /*
-  return true if we are a tailsitter transitioning to VTOL flight  
+  return true if we are a tailsitter transitioning to VTOL flight
  */
 bool QuadPlane::in_tailsitter_vtol_transition(void) const
 {
     return is_tailsitter() && in_vtol_mode() && transition_state == TRANSITION_ANGLE_WAIT_VTOL;
 }
 
+#ifdef DEBUG_SPEED_SCALING
+// first order IIR high pass filter
+// coefficients b0 = b, b1 = -b
+// equation: y_n = b0 x_n + b1 x_{n-1} - a y_{n-1}
+// given b1 = -b0 = b: y_n = b (x_n - x_{n-1} - a y_{n-1}
+// x1 is the new input value, y is the filtered result
+// locatoin x0 is used to save the previous input
+inline void high_pass(float x1, float &x0, float &y) {
+    // coefficients for nyquist/30 cutoff:
+    const float b = 0.974482;
+    const float a = -0.948964;
+    y = b * (x1 - x0) - a * y;
+    x0 = x1;
+}
+
+// log speed scaler and highpass filtered gyro rates for validation
+void QuadPlane::log_CTHP(float spd_scaler, bool airspeed_enabled) {
+
+    // detect oscillation by monitoring gyros
+    Vector3f rates = ahrs_view->get_gyro_latest();
+    static float in0[3] = {0};
+    static float hpOut[3] = {0};
+
+    // highpass filter each gyro output
+    high_pass(rates.x, in0[0], hpOut[0]);
+    high_pass(rates.y, in0[1], hpOut[1]);
+    high_pass(rates.z, in0[2], hpOut[2]);
+
+    // square then lowpass filter the highpass outputs
+    constexpr float lpcoef = 0.02f;
+    static float msq[3] = {0};
+
+    for (int i=0; i<3; i++) {
+        msq[i] = (1 - lpcoef) * msq[i] +lpcoef * sq(hpOut[i]);
+    }
+
+    static uint32_t last_log_time = 0;
+    uint32_t now = AP_HAL::millis();
+    if ((now - last_log_time) >= (1000 / 100)) {
+        last_log_time = now;
+
+        AP::logger().Write("CTHP", "TimeUS,MSQr,MSQp,MSQy,HPr,HPp,HPy,Scl,ASpd", "Qfffffffb",
+                            AP_HAL::micros64(),
+                            msq[0], msq[1], msq[2],
+                            hpOut[0], hpOut[1], hpOut[2],
+                            spd_scaler, airspeed_enabled);
+    }
+}
+#endif
+
 /*
-  account for speed scaling of control surfaces in hover
+  account for speed scaling of control surfaces in VTOL modes
 */
 void QuadPlane::tailsitter_speed_scaling(void)
 {
     const float hover_throttle = motors->get_throttle_hover();
     const float throttle = motors->get_throttle();
-    float scaling;
+    float tthr = 1.25f * hover_throttle;
 
-    if (is_zero(throttle)) {
-        scaling = tailsitter.throttle_scale_max;
+    // critical parameter: violent oscillations if too high
+    // sudden loss of attitude control if too low
+    constexpr float max_atten = 0.2f;
+    float aspeed;
+    float spd_scaler = 1;
+    bool airspeed_enabled = ahrs.airspeed_sensor_enabled();
+
+    if (tailsitter.motor_mask == 0) {
+        if (is_zero(throttle)) {
+            spd_scaler = tailsitter.throttle_scale_max;
+        } else {
+            spd_scaler = constrain_float(hover_throttle / throttle, 0, tailsitter.throttle_scale_max);
+        }
     } else {
-        scaling = constrain_float(hover_throttle / throttle, 0, tailsitter.throttle_scale_max);
-    }
+        // This is a "copter" tailsitter which does not need to boost gain
+        // in hover, but does need reduced gains when flying at high speed in Q modes:
 
-    // if no airspeed sensor reduce throws at large tilt angles (implies high airspeed)
-    if (!ahrs.airspeed_sensor_enabled()) {
-        // ramp down from 1 to max_atten at tilt angles from 45 to 80 degrees
-        constexpr float max_atten = 0.25f;
-        constexpr float c_trans_angle = cosf(M_PI_4);
-        constexpr float alpha = (1 - max_atten) / (c_trans_angle - cosf(radians(80)));
-        constexpr float beta = 1 - alpha * c_trans_angle;
-        const float c_tilt = ahrs_view->get_rotation_body_to_ned().c.z;
-        if (c_tilt < c_trans_angle) {
-            scaling = constrain_float(beta + alpha * c_tilt, max_atten, 1.0f);
+        // If there is an airspeed sensor use the measured airspeed
+        // The airspeed estimate based only on GPS and (estimated) wind is
+        // not sufficiently accurate for tailsitters.
+        // (based on tests in RealFlight 8 with 10kph wind)
+        // TODO: SITL always returns false from airspeed_sensor_enabled()
+        //  (sensor "unhealthy")
+        //  but airspeed_estimate() returns a value
+        if (airspeed_enabled && ahrs.airspeed_estimate(&aspeed)) {
+            // plane.get_speed_scaler() doesn't work well for copter tailsitters
+            // ramp down from 1 to max_atten as speed increases to airspeed_max
+            spd_scaler = constrain_float(1 - (aspeed / plane.aparm.airspeed_max), max_atten, 1.0f);
+        } else {
+            // if no airspeed sensor reduce control surface throws at large tilt
+            // angles (assuming high airspeed)
+
+            // ramp down from 1 to max_atten at tilt angles over trans_angle
+            // (angles here are represented by their cosines)
+            constexpr float c_trans_angle = cosf(.125f * M_PI);
+            constexpr float alpha = (1 - max_atten) / (c_trans_angle - cosf(radians(90)));
+            constexpr float beta = 1 - alpha * c_trans_angle;
+            const float c_tilt = ahrs_view->get_rotation_body_to_ned().c.z;
+            if (c_tilt < c_trans_angle) {
+                spd_scaler = constrain_float(beta + alpha * c_tilt, max_atten, 1.0f);
+                // reduce throttle attenuation threshold too
+                tthr = 0.5f * hover_throttle;
+            }
         }
         // if throttle is above hover thrust, apply additional attenuation
-        const float tthr = 0.5f * hover_throttle;
         if (throttle > tthr) {
             const float throttle_atten = 1 - (throttle - tthr) / (1 - tthr);
-            scaling *= throttle_atten;
-            scaling = constrain_float(scaling, .2f, 1.0f);
+            spd_scaler *= throttle_atten;
+            spd_scaler = constrain_float(spd_scaler, max_atten, 1.0f);
         }
     }
+    // limit positive and negative slew rates of applied speed scaling
+    constexpr float posTC = 5.0f;   // seconds
+    constexpr float negTC = 2.0f;   // seconds
+    const float posdelta = plane.G_Dt / posTC;
+    const float negdelta = plane.G_Dt / negTC;
+    static float last_fscale = 0;
+    static float fscale = 0;
+    if ((spd_scaler - last_fscale) > 0) {
+        if ((spd_scaler - last_fscale) > posdelta) {
+            fscale += posdelta;
+        } else {
+            fscale = spd_scaler;
+        }
+    } else {
+        if ((spd_scaler - last_fscale) < -negdelta) {
+            fscale -= negdelta;
+        } else {
+            fscale = spd_scaler;
+        }
+    }
+    last_fscale = fscale;
+
+    if (DEBUG_SPEED_SCALING) {
+        log_CTHP(fscale, airspeed_enabled);
+    }
+
     const SRV_Channel::Aux_servo_function_t functions[4] = {
         SRV_Channel::Aux_servo_function_t::k_aileron,
         SRV_Channel::Aux_servo_function_t::k_elevator,
@@ -269,9 +375,9 @@ void QuadPlane::tailsitter_speed_scaling(void)
         SRV_Channel::Aux_servo_function_t::k_tiltMotorRight};
     for (uint8_t i=0; i<ARRAY_SIZE(functions); i++) {
         int32_t v = SRV_Channels::get_output_scaled(functions[i]);
-        v *= scaling;
+        v *= fscale;
         v = constrain_int32(v, -SERVO_MAX, SERVO_MAX);
         SRV_Channels::set_output_scaled(functions[i], v);
     }
 }
-    
+

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -26,7 +26,8 @@
 #define AC_ATTITUDE_RATE_RP_CONTROLLER_OUT_MAX          1.0f    // body-frame rate controller maximum output (for roll-pitch axis)
 #define AC_ATTITUDE_RATE_YAW_CONTROLLER_OUT_MAX         1.0f    // body-frame rate controller maximum output (for yaw axis)
 
-#define AC_ATTITUDE_THRUST_ERROR_ANGLE                  radians(30.0f) // Thrust angle error above which yaw corrections are limited
+// This must be increased from 30 degrees for copter tailsitters, otherwise there can be sudden loss of control
+#define AC_ATTITUDE_THRUST_ERROR_ANGLE                  radians(120.0f) // Thrust angle error above which yaw corrections are limited
 
 #define AC_ATTITUDE_400HZ_DT                            0.0025f // delta time in seconds for 400hz update rate
 

--- a/libraries/AP_Motors/AP_Motors.h
+++ b/libraries/AP_Motors/AP_Motors.h
@@ -11,3 +11,4 @@
 #include "AP_MotorsCoax.h"
 #include "AP_MotorsTailsitter.h"
 #include "AP_Motors6DOF.h"
+#include "AP_MotorsMatrixTS.h"

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.cpp
@@ -1,0 +1,125 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ *       AP_MotorsMatrixTS.cpp - tailsitters with multicopter motor configuration
+ */
+
+#include <AP_BattMonitor/AP_BattMonitor.h>
+#include <AP_HAL/AP_HAL.h>
+#include "AP_MotorsMatrixTS.h"
+
+extern const AP_HAL::HAL& hal;
+
+#define SERVO_OUTPUT_RANGE  4500
+
+// output a thrust to all motors that match a given motor mask. This
+// is used to control motors enabled for forward flight. Thrust is in
+// the range 0 to 1
+void AP_MotorsMatrixTS::output_motor_mask(float thrust, uint8_t mask, float rudder_dt)
+{
+    const int16_t pwm_min = get_pwm_output_min();
+    const int16_t pwm_range = get_pwm_output_max() - pwm_min;
+
+    for (uint8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        if (motor_enabled[i]) {
+            int16_t motor_out;
+            if (mask & (1U<<i)) {
+                /*
+                    apply rudder mixing differential thrust
+                    copter frame roll is plane frame yaw (this is only
+                    used by tiltrotors and tailsitters)
+                */
+                float diff_thrust = get_roll_factor(i) * rudder_dt * 0.5f;
+                motor_out = pwm_min + pwm_range * constrain_float(thrust + diff_thrust, 0.0f, 1.0f);
+            } else {
+                motor_out = pwm_min;
+            }
+            rc_write(i, motor_out);
+        }
+    }
+}
+
+void AP_MotorsMatrixTS::output_to_motors()
+{
+    // calls calc_thrust_to_pwm(_thrust_rpyt_out[i]) for each enabled motor
+    AP_MotorsMatrix::output_to_motors();
+
+    // also actuate control surfaces
+    SRV_Channels::set_output_scaled(SRV_Channel::k_aileron,  -_yaw_in * SERVO_OUTPUT_RANGE);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, _pitch_in * SERVO_OUTPUT_RANGE);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, _roll_in * SERVO_OUTPUT_RANGE);
+}
+
+void AP_MotorsMatrixTS::output_armed_stabilizing()
+{
+    // calculates thrust values _thrust_rpyt_out
+    AP_MotorsMatrix::output_armed_stabilizing();
+}
+
+void AP_MotorsMatrixTS::setup_motors(motor_frame_class frame_class, motor_frame_type frame_type)
+{
+    // remove existing motors
+    for (int8_t i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
+        remove_motor(i);
+    }
+
+    bool success = false;
+
+    switch (frame_class) {
+
+        case MOTOR_FRAME_TRI:
+            // frame_type ignored since only one frame type is currently supported
+            add_motor(AP_MOTORS_MOT_1,  90, 0, 2);
+            add_motor(AP_MOTORS_MOT_2, -90, 0, 4);
+            add_motor(AP_MOTORS_MOT_4, 180, 0, 3);
+            success = true;
+            break;
+        case MOTOR_FRAME_QUAD:
+            switch (frame_type) {
+                case MOTOR_FRAME_TYPE_PLUS:
+                    // motors 1,2 on wings, motors 3,4 on vertical tail/subfin
+                    // motors 1,2 are counter-rotating, as are motors 3,4
+                    // left wing motor is CW (looking from front)
+                    // don't think it matters which of 3,4 is CW
+                    add_motor(AP_MOTORS_MOT_1,  90, 0, 2);
+                    add_motor(AP_MOTORS_MOT_2, -90, 0, 4);
+                    add_motor(AP_MOTORS_MOT_3,   0, 0, 1);
+                    add_motor(AP_MOTORS_MOT_4, 180, 0, 3);
+                    success = true;
+                    break;
+                case MOTOR_FRAME_TYPE_X:
+                    // PLUS_TS layout rotated 45 degrees about X axis
+                    add_motor(AP_MOTORS_MOT_1,   45, 0, 1);
+                    add_motor(AP_MOTORS_MOT_2, -135, 0, 3);
+                    add_motor(AP_MOTORS_MOT_3,  -45, 0, 4);
+                    add_motor(AP_MOTORS_MOT_4,  135, 0, 2);
+                    success = true;
+                    break;
+                default:
+                    // matrixTS doesn't support the configured frame_type
+                    break;
+            }
+
+        default:
+            // matrixTS doesn't support the configured frame_class
+            break;
+        } // switch frame_class
+
+    // normalise factors to magnitude 0.5
+    normalise_rpy_factors();
+
+    _flags.initialised_ok = success;
+}

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.h
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.h
@@ -1,0 +1,30 @@
+/// @file	AP_MotorsMatrixTS.h
+/// @brief	Motor control class for tailsitters with multicopter motor configurations
+
+#pragma once
+
+#include <AP_Common/AP_Common.h>
+#include <AP_Math/AP_Math.h>
+#include <SRV_Channel/SRV_Channel.h>
+#include "AP_MotorsMatrix.h"
+
+/// @class      AP_MotorsMatrix
+class AP_MotorsMatrixTS : public AP_MotorsMatrix {
+public:
+
+    AP_MotorsMatrixTS(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT) :
+        AP_MotorsMatrix(loop_rate, speed_hz) {
+        AP_Param::setup_object_defaults(this, var_info);
+    };
+
+    virtual void        output_to_motors() override;
+
+    virtual void        output_motor_mask(float thrust, uint8_t mask, float rudder_dt) override;
+
+protected:
+    // configures the motors for the defined frame_class and frame_type
+    virtual void        setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override;
+
+    // calculate motor outputs
+    void                output_armed_stabilizing() override;
+};

--- a/libraries/AP_Motors/AP_MotorsMatrixTS.h
+++ b/libraries/AP_Motors/AP_MotorsMatrixTS.h
@@ -21,6 +21,10 @@ public:
 
     virtual void        output_motor_mask(float thrust, uint8_t mask, float rudder_dt) override;
 
+    float* get_rpyt() {
+        return _thrust_rpyt_out;
+    }
+
 protected:
     // configures the motors for the defined frame_class and frame_type
     virtual void        setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override;


### PR DESCRIPTION
- [x] needs work on throttle to utilize hover thrust for mid-stick
mode QACRO is 23; mavproxy won't know it yet
Flies just like a helicopter in heading-lock mode; must coordinate rudder with aileron to turn
