### PR TITLE
Move frame_strings from Copter to Motors

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -865,7 +865,6 @@ private:
     void update_auto_armed();
     bool should_log(uint32_t mask);
     MAV_TYPE get_frame_mav_type();
-    const char* get_frame_string();
     void allocate_motors(void);
     bool is_tradheli() const;
 

--- a/ArduCopter/GCS_Copter.cpp
+++ b/ArduCopter/GCS_Copter.cpp
@@ -9,7 +9,7 @@ uint8_t GCS_Copter::sysid_this_mav() const
 
 const char* GCS_Copter::frame_string() const
 {
-    return copter.get_frame_string();
+    return copter.motors->get_frame_string();
 }
 
 bool GCS_Copter::simple_input_active() const

--- a/ArduCopter/GCS_Mavlink.cpp
+++ b/ArduCopter/GCS_Mavlink.cpp
@@ -529,7 +529,7 @@ bool GCS_MAVLINK_Copter::params_ready() const
 void GCS_MAVLINK_Copter::send_banner()
 {
     GCS_MAVLINK::send_banner();
-    send_text(MAV_SEVERITY_INFO, "Frame: %s", copter.get_frame_string());
+    send_text(MAV_SEVERITY_INFO, "Frame: %s", copter.motors->get_frame_string());
 }
 
 // a RC override message is considered to be a 'heartbeat' from the ground station for failsafe purposes

--- a/ArduCopter/Log.cpp
+++ b/ArduCopter/Log.cpp
@@ -617,7 +617,7 @@ const struct LogStructure Copter::log_structure[] = {
 void Copter::Log_Write_Vehicle_Startup_Messages()
 {
     // only 200(?) bytes are guaranteed by AP_Logger
-    logger.Write_MessageF("Frame: %s", get_frame_string());
+    logger.Write_MessageF("Frame: %s, Type: %s", motors->get_frame_string(), motors->get_type_string());
     logger.Write_Mode((uint8_t)control_mode, control_mode_reason);
     ahrs.Log_Write_Home_And_Origin();
     gps.Write_AP_Logger_Log_Startup_messages();

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -474,42 +474,6 @@ MAV_TYPE Copter::get_frame_mav_type()
     return MAV_TYPE_GENERIC;
 }
 
-// return string corresponding to frame_class
-const char* Copter::get_frame_string()
-{
-    switch ((AP_Motors::motor_frame_class)g2.frame_class.get()) {
-        case AP_Motors::MOTOR_FRAME_QUAD:
-            return "QUAD";
-        case AP_Motors::MOTOR_FRAME_HEXA:
-            return "HEXA";
-        case AP_Motors::MOTOR_FRAME_Y6:
-            return "Y6";
-        case AP_Motors::MOTOR_FRAME_OCTA:
-            return "OCTA";
-        case AP_Motors::MOTOR_FRAME_OCTAQUAD:
-            return "OCTA_QUAD";
-        case AP_Motors::MOTOR_FRAME_HELI:
-            return "HELI";
-        case AP_Motors::MOTOR_FRAME_HELI_DUAL:
-            return "HELI_DUAL";
-        case AP_Motors::MOTOR_FRAME_HELI_QUAD:
-            return "HELI_QUAD";
-        case AP_Motors::MOTOR_FRAME_TRI:
-            return "TRI";
-        case AP_Motors::MOTOR_FRAME_SINGLE:
-            return "SINGLE";
-        case AP_Motors::MOTOR_FRAME_COAX:
-            return "COAX";
-        case AP_Motors::MOTOR_FRAME_TAILSITTER:
-            return "TAILSITTER";
-        case AP_Motors::MOTOR_FRAME_DODECAHEXA:
-            return "DODECA_HEXA";
-        case AP_Motors::MOTOR_FRAME_UNDEFINED:
-        default:
-            return "UNKNOWN";
-    }
-}
-
 /*
   allocate the motors class
  */

--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -512,6 +512,10 @@ void Plane::Log_Write_Vehicle_Startup_Messages()
 {
     // only 200(?) bytes are guaranteed by AP_Logger
     Log_Write_Startup(TYPE_GROUNDSTART_MSG);
+    if (quadplane.initialised) {
+        logger.Write_MessageF("QuadPlane Frame: %s, Type: %s", quadplane.motors->get_frame_string(),
+                                                               quadplane.motors->get_type_string());
+    }
     logger.Write_Mode(control_mode->mode_number(), control_mode_reason);
     ahrs.Log_Write_Home_And_Origin();
     gps.Write_AP_Logger_Log_Startup_messages();

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -595,6 +595,7 @@ bool QuadPlane::setup(void)
     float loop_delta_t = 1.0 / plane.scheduler.get_loop_rate_hz();
 
     enum AP_Motors::motor_frame_class motor_class;
+    enum AP_Motors::motor_frame_type motor_type;
     enum Rotation rotation = ROTATION_NONE;
 
     /*
@@ -624,8 +625,6 @@ bool QuadPlane::setup(void)
         }
         frame_class.set_and_save(new_value);
     }
-    gcs().send_text(MAV_SEVERITY_INFO, "QuadPlane initialise, class: %u, type: %u", 
-                    (unsigned)frame_class.get(), (unsigned)frame_type.get());
     
     if (hal.util->available_memory() <
         4096 + sizeof(*motors) + sizeof(*attitude_control) + sizeof(*pos_control) + sizeof(*wp_nav) + sizeof(*ahrs_view) + sizeof(*loiter_nav)) {
@@ -637,7 +636,9 @@ bool QuadPlane::setup(void)
       that the objects don't affect the vehicle unless enabled and
       also saves memory when not in use
      */
-    motor_class = (enum AP_Motors::motor_frame_class)frame_class.get();
+    motor_class = (AP_Motors::motor_frame_class)frame_class.get();
+    motor_type  = (AP_Motors::motor_frame_type)frame_type.get();
+    bool coptar_tailsitter_supported = true;
     switch (motor_class) {
     case AP_Motors::MOTOR_FRAME_QUAD:
         setup_default_channels(4);
@@ -658,12 +659,15 @@ bool QuadPlane::setup(void)
         SRV_Channels::set_default_function(CH_8, SRV_Channel::k_motor4);
         SRV_Channels::set_default_function(CH_11, SRV_Channel::k_motor7);
         AP_Param::set_frame_type_flags(AP_PARAM_FRAME_TRICOPTER);
+        coptar_tailsitter_supported = false;
         break;
     case AP_Motors::MOTOR_FRAME_TAILSITTER:
+        coptar_tailsitter_supported = false;
         break;
     default:
-        AP_BoardConfig::config_error("Unknown Q_FRAME_CLASS %u", (unsigned)frame_class.get());
+        AP_BoardConfig::config_error("Unsupported Q_FRAME_CLASS %u", motor_class);
     }
+    ::printf("QuadPlane initialise, class: %u, type: %u\n", motor_class, motor_type);
 
     if (tailsitter.motor_mask == 0) {
         // this is a normal quadplane
@@ -688,8 +692,12 @@ bool QuadPlane::setup(void)
     } else {
         // this is a copter tailsitter with motor layout specified by frame_class and frame_type
         // tilting motors are not supported (tiltrotor control variables are ignored)
+        if (!coptar_tailsitter_supported) {
+            AP_BoardConfig::config_error("unsupported copterTS class: %u", motor_class);
+        }
+        ::printf("configuring copter tailsitter\n");
         if (tilt.tilt_mask != 0) {
-            gcs().send_text(MAV_SEVERITY_INFO, "Warning: Motor tilt not supported");
+            ::printf("Warning: Motor tilt not supported\n");
         }
         rotation = ROTATION_PITCH_90;
         motors = new AP_MotorsMatrix(plane.scheduler.get_loop_rate_hz(), rc_speed);
@@ -730,10 +738,10 @@ bool QuadPlane::setup(void)
     }
     AP_Param::load_object_from_eeprom(loiter_nav, loiter_nav->var_info);
 
-    motors->init((AP_Motors::motor_frame_class)frame_class.get(), (AP_Motors::motor_frame_type)frame_type.get());
+    motors->init(motor_class, motor_type);
 
     if (!motors->initialised_ok()) {
-        AP_BoardConfig::config_error("unknown Q_FRAME_TYPE %u", (unsigned)frame_type.get());
+        AP_BoardConfig::config_error("init failed: class: %u type: %u", motor_class, motor_type);
     }
     motors->set_throttle_range(thr_min_pwm, thr_max_pwm);
     motors->set_update_rate(rc_speed);
@@ -772,7 +780,7 @@ bool QuadPlane::setup(void)
     // param count will have changed
     AP_Param::invalidate_count();
 
-    gcs().send_text(MAV_SEVERITY_INFO, "QuadPlane initialised");
+    ::printf("QuadPlane initialised, class: %s, type: %s\n", motors->get_frame_string(), motors->get_type_string());
     initialised = true;
     return true;
 }

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -283,9 +283,9 @@ float AP_Motors6DOF::get_current_limit_max_throttle()
 // ToDo calculate headroom for rpy to be added for stabilization during full throttle/forward/lateral commands
 void AP_Motors6DOF::output_armed_stabilizing()
 {
-    if ((sub_frame_t)_last_frame_class == SUB_FRAME_VECTORED) {
+    if ((sub_frame_t)_active_frame_class == SUB_FRAME_VECTORED) {
         output_armed_stabilizing_vectored();
-    } else if ((sub_frame_t)_last_frame_class == SUB_FRAME_VECTORED_6DOF) {
+    } else if ((sub_frame_t)_active_frame_class == SUB_FRAME_VECTORED_6DOF) {
         output_armed_stabilizing_vectored_6dof();
     } else {
         uint8_t i;                          // general purpose counter

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -132,6 +132,7 @@ void AP_Motors6DOF::setup_motors(motor_frame_class frame_class, motor_frame_type
     switch ((sub_frame_t)frame_class) {
         //                 Motor #              Roll Factor     Pitch Factor    Yaw Factor      Throttle Factor     Forward Factor      Lateral Factor  Testing Order
     case SUB_FRAME_BLUEROV1:
+        _frame_class_string = "BLUEROV1";
         add_motor_raw_6dof(AP_MOTORS_MOT_1,     0,              0,              -1.0f,          0,                  1.0f,               0,              1);
         add_motor_raw_6dof(AP_MOTORS_MOT_2,     0,              0,              1.0f,           0,                  1.0f,               0,              2);
         add_motor_raw_6dof(AP_MOTORS_MOT_3,     -0.5f,          0.5f,           0,              0.45f,              0,                  0,              3);
@@ -141,6 +142,7 @@ void AP_Motors6DOF::setup_motors(motor_frame_class frame_class, motor_frame_type
         break;
 
     case SUB_FRAME_VECTORED_6DOF_90DEG:
+        _frame_class_string = "VECTORED_6DOF_90DEG";
         add_motor_raw_6dof(AP_MOTORS_MOT_1,     1.0f,           1.0f,           0,              1.0f,               0,                  0,              1);
         add_motor_raw_6dof(AP_MOTORS_MOT_2,     0,              0,              1.0f,           0,                  1.0f,               0,              2);
         add_motor_raw_6dof(AP_MOTORS_MOT_3,     1.0f,           -1.0f,          0,              1.0f,               0,                  0,              3);
@@ -152,6 +154,7 @@ void AP_Motors6DOF::setup_motors(motor_frame_class frame_class, motor_frame_type
         break;
 
     case SUB_FRAME_VECTORED_6DOF:
+        _frame_class_string = "VECTORED_6DOF";
         add_motor_raw_6dof(AP_MOTORS_MOT_1,     0,              0,              1.0f,           0,                  -1.0f,              1.0f,           1);
         add_motor_raw_6dof(AP_MOTORS_MOT_2,     0,              0,              -1.0f,          0,                  -1.0f,              -1.0f,          2);
         add_motor_raw_6dof(AP_MOTORS_MOT_3,     0,              0,              -1.0f,          0,                  1.0f,               1.0f,           3);
@@ -163,6 +166,7 @@ void AP_Motors6DOF::setup_motors(motor_frame_class frame_class, motor_frame_type
         break;
 
     case SUB_FRAME_VECTORED:
+        _frame_class_string = "VECTORED";
         add_motor_raw_6dof(AP_MOTORS_MOT_1,     0,              0,              1.0f,           0,                  -1.0f,              1.0f,           1);
         add_motor_raw_6dof(AP_MOTORS_MOT_2,     0,              0,              -1.0f,          0,                  -1.0f,              -1.0f,          2);
         add_motor_raw_6dof(AP_MOTORS_MOT_3,     0,              0,              -1.0f,          0,                  1.0f,               1.0f,           3);
@@ -176,6 +180,7 @@ void AP_Motors6DOF::setup_motors(motor_frame_class frame_class, motor_frame_type
         //break;
 
     case SUB_FRAME_SIMPLEROV_3:
+        _frame_class_string = "SIMPLEROV_3";
         add_motor_raw_6dof(AP_MOTORS_MOT_1,     0,              0,              -1.0f,          0,                  1.0f,               0,              1);
         add_motor_raw_6dof(AP_MOTORS_MOT_2,     0,              0,              1.0f,           0,                  1.0f,               0,              2);
         add_motor_raw_6dof(AP_MOTORS_MOT_3,     0,              0,              0,              -1.0f,              0,                  0,              3);
@@ -183,6 +188,7 @@ void AP_Motors6DOF::setup_motors(motor_frame_class frame_class, motor_frame_type
     case SUB_FRAME_SIMPLEROV_4:
     case SUB_FRAME_SIMPLEROV_5:
     default:
+        _frame_class_string = "DEFAULT";
         add_motor_raw_6dof(AP_MOTORS_MOT_1,     0,              0,              -1.0f,          0,                  1.0f,               0,              1);
         add_motor_raw_6dof(AP_MOTORS_MOT_2,     0,              0,              1.0f,           0,                  1.0f,               0,              2);
         add_motor_raw_6dof(AP_MOTORS_MOT_3,     1.0f,           0,              0,              -1.0f,              0,                  0,              3);

--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -29,6 +29,30 @@ public:
         SUB_FRAME_CUSTOM
     } sub_frame_t;
 
+    const char* get_frame_string() override
+    {
+        switch ((sub_frame_t)_active_frame_class) {
+            case sub_frame_t::SUB_FRAME_BLUEROV1:
+                return "BLUEROV1";
+            case sub_frame_t::SUB_FRAME_VECTORED:
+                return "VECTORED";
+            case sub_frame_t::SUB_FRAME_VECTORED_6DOF:
+                return "VECTORED_6DOF";
+            case sub_frame_t::SUB_FRAME_VECTORED_6DOF_90DEG:
+                return "VECTORED_6DOF_90DEG";
+            case sub_frame_t::SUB_FRAME_SIMPLEROV_3:
+                return "SIMPLEROV_3";
+            case sub_frame_t::SUB_FRAME_SIMPLEROV_4:
+                return "SIMPLEROV_4";
+            case sub_frame_t::SUB_FRAME_SIMPLEROV_5:
+                return "SIMPLEROV_5";
+            case sub_frame_t::SUB_FRAME_CUSTOM:
+                return "CUSTOM";
+            default:
+                return "UNKNOWN";
+        }
+    };
+
     // Override parent
     void setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override;
 

--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -29,29 +29,7 @@ public:
         SUB_FRAME_CUSTOM
     } sub_frame_t;
 
-    const char* get_frame_string() override
-    {
-        switch ((sub_frame_t)_active_frame_class) {
-            case sub_frame_t::SUB_FRAME_BLUEROV1:
-                return "BLUEROV1";
-            case sub_frame_t::SUB_FRAME_VECTORED:
-                return "VECTORED";
-            case sub_frame_t::SUB_FRAME_VECTORED_6DOF:
-                return "VECTORED_6DOF";
-            case sub_frame_t::SUB_FRAME_VECTORED_6DOF_90DEG:
-                return "VECTORED_6DOF_90DEG";
-            case sub_frame_t::SUB_FRAME_SIMPLEROV_3:
-                return "SIMPLEROV_3";
-            case sub_frame_t::SUB_FRAME_SIMPLEROV_4:
-                return "SIMPLEROV_4";
-            case sub_frame_t::SUB_FRAME_SIMPLEROV_5:
-                return "SIMPLEROV_5";
-            case sub_frame_t::SUB_FRAME_CUSTOM:
-                return "CUSTOM";
-            default:
-                return "UNKNOWN";
-        }
-    };
+    const char* get_frame_string() override { return _frame_class_string; };
 
     // Override parent
     void setup_motors(motor_frame_class frame_class, motor_frame_type frame_type) override;

--- a/libraries/AP_Motors/AP_MotorsCoax.h
+++ b/libraries/AP_Motors/AP_MotorsCoax.h
@@ -49,6 +49,8 @@ public:
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint16_t            get_motor_mask() override;
 
+    const char* get_frame_string() override { return "COAX"; }
+
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -136,6 +136,8 @@ public:
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
+    const char* get_frame_string() override { return "HELI"; }
+
 protected:
 
     // manual servo modes (used for setup)

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.h
@@ -98,6 +98,8 @@ public:
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
+    const char* get_frame_string() override { return "HELI_DUAL"; }
+
 protected:
 
     // init_outputs

--- a/libraries/AP_Motors/AP_MotorsHeli_Quad.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Quad.h
@@ -77,6 +77,8 @@ public:
     // var_info for holding Parameter information
     static const struct AP_Param::GroupInfo var_info[];
 
+    const char* get_frame_string() override { return "HELI_QUAD"; }
+
 protected:
 
     // init_outputs

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -23,8 +23,8 @@ extern const AP_HAL::HAL& hal;
 void AP_MotorsMatrix::init(motor_frame_class frame_class, motor_frame_type frame_type)
 {
     // record requested frame class and type
-    _last_frame_class = frame_class;
-    _last_frame_type = frame_type;
+    _active_frame_class = frame_class;
+    _active_frame_type = frame_type;
 
     // setup the motors
     setup_motors(frame_class, frame_type);
@@ -52,11 +52,11 @@ void AP_MotorsMatrix::set_update_rate(uint16_t speed_hz)
 void AP_MotorsMatrix::set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type)
 {
     // exit immediately if armed or no change
-    if (armed() || (frame_class == _last_frame_class && _last_frame_type == frame_type)) {
+    if (armed() || (frame_class == _active_frame_class && _active_frame_type == frame_type)) {
         return;
     }
-    _last_frame_class = frame_class;
-    _last_frame_type = frame_type;
+    _active_frame_class = frame_class;
+    _active_frame_type = frame_type;
 
     // setup the motors
     setup_motors(frame_class, frame_type);

--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -492,14 +492,17 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
     switch (frame_class) {
 
         case MOTOR_FRAME_QUAD:
+            _frame_class_string = "QUAD";
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
+                    _frame_type_string = "PLUS";
                     add_motor(AP_MOTORS_MOT_1,  90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 2);
                     add_motor(AP_MOTORS_MOT_2, -90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 4);
                     add_motor(AP_MOTORS_MOT_3,   0, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
                     add_motor(AP_MOTORS_MOT_4, 180, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
                     break;
                 case MOTOR_FRAME_TYPE_X:
+                    _frame_type_string = "X";
                     add_motor(AP_MOTORS_MOT_1,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor(AP_MOTORS_MOT_2, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3);
                     add_motor(AP_MOTORS_MOT_3,  -45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  4);
@@ -507,12 +510,14 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane) 
                 case MOTOR_FRAME_TYPE_NYT_PLUS:
+                    _frame_type_string = "NYT_PLUS";
                     add_motor(AP_MOTORS_MOT_1,  90, 0, 2);
                     add_motor(AP_MOTORS_MOT_2, -90, 0, 4);
                     add_motor(AP_MOTORS_MOT_3,   0, 0, 1);
                     add_motor(AP_MOTORS_MOT_4, 180, 0, 3);
                     break;
                 case MOTOR_FRAME_TYPE_NYT_X:
+                    _frame_type_string = "NYT_X";
                     add_motor(AP_MOTORS_MOT_1,   45, 0, 1);
                     add_motor(AP_MOTORS_MOT_2, -135, 0, 3);
                     add_motor(AP_MOTORS_MOT_3,  -45, 0, 4);
@@ -522,6 +527,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                 case MOTOR_FRAME_TYPE_BF_X:
                     // betaflight quad X order
                     // see: https://fpvfrenzy.com/betaflight-motor-order/
+                    _frame_type_string = "BF_X";
                     add_motor(AP_MOTORS_MOT_1,  135, AP_MOTORS_MATRIX_YAW_FACTOR_CW, 2);
                     add_motor(AP_MOTORS_MOT_2,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,1);
                     add_motor(AP_MOTORS_MOT_3, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,3);
@@ -529,6 +535,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 case MOTOR_FRAME_TYPE_BF_X_REV:
                     // betaflight quad X order, reversed motors
+                    _frame_type_string = "X_REV";
                     add_motor(AP_MOTORS_MOT_1,  135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 2);
                     add_motor(AP_MOTORS_MOT_2,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
                     add_motor(AP_MOTORS_MOT_3, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
@@ -537,6 +544,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                 case MOTOR_FRAME_TYPE_DJI_X:
                     // DJI quad X order
                     // see https://forum44.djicdn.com/data/attachment/forum/201711/26/172348bppvtt1ot1nrtp5j.jpg
+                    _frame_type_string = "DJI_X";
                     add_motor(AP_MOTORS_MOT_1,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor(AP_MOTORS_MOT_2,  -45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  4);
                     add_motor(AP_MOTORS_MOT_3, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3);
@@ -545,12 +553,14 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                 case MOTOR_FRAME_TYPE_CW_X:
                     // "clockwise X" motor order. Motors are ordered clockwise from front right
                     // matching test order
+                    _frame_type_string = "CW_X";
                     add_motor(AP_MOTORS_MOT_1,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor(AP_MOTORS_MOT_2,  135, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2);
                     add_motor(AP_MOTORS_MOT_3, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3);
                     add_motor(AP_MOTORS_MOT_4,  -45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  4);
                     break;
                 case MOTOR_FRAME_TYPE_V:
+                    _frame_type_string = "V";
                     add_motor(AP_MOTORS_MOT_1,   45,  0.7981f,  1);
                     add_motor(AP_MOTORS_MOT_2, -135,  1.0000f,  3);
                     add_motor(AP_MOTORS_MOT_3,  -45, -0.7981f,  4);
@@ -558,6 +568,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 case MOTOR_FRAME_TYPE_H:
                     // H frame set-up - same as X but motors spin in opposite directiSons
+                    _frame_type_string = "H";
                     add_motor(AP_MOTORS_MOT_1,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
                     add_motor(AP_MOTORS_MOT_2, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
                     add_motor(AP_MOTORS_MOT_3,  -45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 4);
@@ -579,6 +590,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                             motors 1's yaw factor should be changed to sin(radians(40)).  Where "40" is the vtail angle
                             motors 3's yaw factor should be changed to -sin(radians(40))
                     */
+                    _frame_type_string = "VTAIL";
                     add_motor(AP_MOTORS_MOT_1, 60, 60, 0, 1);
                     add_motor(AP_MOTORS_MOT_2, 0, -160, AP_MOTORS_MATRIX_YAW_FACTOR_CW, 3);
                     add_motor(AP_MOTORS_MOT_3, -60, -60, 0, 4);
@@ -598,6 +610,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                         - Yaw control is entirely in the rear motors
                         - Roll is is entirely in the front motors
                     */
+                    _frame_type_string = "ATAIL";
                     add_motor(AP_MOTORS_MOT_1, 60, 60, 0, 1);
                     add_motor(AP_MOTORS_MOT_2, 0, -160, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3);
                     add_motor(AP_MOTORS_MOT_3, -60, -60, 0, 4);
@@ -605,6 +618,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 case MOTOR_FRAME_TYPE_PLUSREV:
                     // plus with reversed motor directions
+                    _frame_type_string = "PLUSREV";
                     add_motor(AP_MOTORS_MOT_1, 90, AP_MOTORS_MATRIX_YAW_FACTOR_CW, 2);
                     add_motor(AP_MOTORS_MOT_2, -90, AP_MOTORS_MATRIX_YAW_FACTOR_CW, 4);
                     add_motor(AP_MOTORS_MOT_3, 0, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
@@ -612,14 +626,17 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 default:
                     // quad frame class does not support this frame type
+                    _frame_type_string = "UNSUPPORTED";
                     success = false;
                     break;
             }
             break;  // quad
 
         case MOTOR_FRAME_HEXA:
+            _frame_class_string = "HEXA";
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
+                    _frame_type_string = "PLUS";
                     add_motor(AP_MOTORS_MOT_1,   0, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
                     add_motor(AP_MOTORS_MOT_2, 180, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 4);
                     add_motor(AP_MOTORS_MOT_3,-120, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  5);
@@ -628,6 +645,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor(AP_MOTORS_MOT_6, 120, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
                     break;
                 case MOTOR_FRAME_TYPE_X:
+                    _frame_type_string = "X";
                     add_motor(AP_MOTORS_MOT_1,  90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2);
                     add_motor(AP_MOTORS_MOT_2, -90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 5);
                     add_motor(AP_MOTORS_MOT_3, -30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  6);
@@ -637,6 +655,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 case MOTOR_FRAME_TYPE_H:
                     // H is same as X except middle motors are closer to center
+                    _frame_type_string = "H";
                     add_motor_raw(AP_MOTORS_MOT_1, -1.0f, 0.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW, 2);
                     add_motor_raw(AP_MOTORS_MOT_2, 1.0f, 0.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 5);
                     add_motor_raw(AP_MOTORS_MOT_3, 1.0f, 1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW, 6);
@@ -645,6 +664,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor_raw(AP_MOTORS_MOT_6, 1.0f, -1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW, 4);
                     break;
                 case MOTOR_FRAME_TYPE_DJI_X:
+                    _frame_type_string = "DJI_X";
                     add_motor(AP_MOTORS_MOT_1,   30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor(AP_MOTORS_MOT_2,  -30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  6);
                     add_motor(AP_MOTORS_MOT_3,  -90, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 5);
@@ -653,6 +673,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor(AP_MOTORS_MOT_6,   90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2);
                     break;
                 case MOTOR_FRAME_TYPE_CW_X:
+                    _frame_type_string = "CW_X";
                     add_motor(AP_MOTORS_MOT_1,   30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor(AP_MOTORS_MOT_2,   90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2);
                     add_motor(AP_MOTORS_MOT_3,  150, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3);
@@ -662,14 +683,17 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 default:
                     // hexa frame class does not support this frame type
+                    _frame_type_string = "UNSUPPORTED";
                     success = false;
                     break;
             }
             break;
 
         case MOTOR_FRAME_OCTA:
+            _frame_class_string = "OCTA";
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
+                    _frame_type_string = "PLUS";
                     add_motor(AP_MOTORS_MOT_1,    0,  AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
                     add_motor(AP_MOTORS_MOT_2,  180,  AP_MOTORS_MATRIX_YAW_FACTOR_CW,  5);
                     add_motor(AP_MOTORS_MOT_3,   45,  AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 2);
@@ -680,6 +704,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor(AP_MOTORS_MOT_8,   90,  AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
                     break;
                 case MOTOR_FRAME_TYPE_X:
+                    _frame_type_string = "X";
                     add_motor(AP_MOTORS_MOT_1,   22.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
                     add_motor(AP_MOTORS_MOT_2, -157.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  5);
                     add_motor(AP_MOTORS_MOT_3,   67.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 2);
@@ -690,6 +715,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor(AP_MOTORS_MOT_8,  112.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
                     break;
                 case MOTOR_FRAME_TYPE_V:
+                    _frame_type_string = "V";
                     add_motor_raw(AP_MOTORS_MOT_1,  0.83f,  0.34f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  7);
                     add_motor_raw(AP_MOTORS_MOT_2, -0.67f, -0.32f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
                     add_motor_raw(AP_MOTORS_MOT_3,  0.67f, -0.32f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 6);
@@ -700,6 +726,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor_raw(AP_MOTORS_MOT_8,  0.50f, -1.00f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  5);
                     break;
                 case MOTOR_FRAME_TYPE_H:
+                    _frame_type_string = "H";
                     add_motor_raw(AP_MOTORS_MOT_1, -1.0f,    1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
                     add_motor_raw(AP_MOTORS_MOT_2,  1.0f,   -1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  5);
                     add_motor_raw(AP_MOTORS_MOT_3, -1.0f,  0.333f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 2);
@@ -710,6 +737,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor_raw(AP_MOTORS_MOT_8, -1.0f, -0.333f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
                     break;
                 case MOTOR_FRAME_TYPE_I:
+                    _frame_type_string = "I";
                     add_motor_raw(AP_MOTORS_MOT_1, 0.333f, -1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
                     add_motor_raw(AP_MOTORS_MOT_2, -0.333f,  1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  5);
                     add_motor_raw(AP_MOTORS_MOT_3,    1.0f, -1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 2);
@@ -720,6 +748,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor_raw(AP_MOTORS_MOT_8,    1.0f,  1.0f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
                     break;
                 case MOTOR_FRAME_TYPE_DJI_X:
+                    _frame_type_string = "DJI_X";
                     add_motor(AP_MOTORS_MOT_1,   22.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor(AP_MOTORS_MOT_2,  -22.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  8);
                     add_motor(AP_MOTORS_MOT_3,  -67.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 7);
@@ -730,6 +759,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor(AP_MOTORS_MOT_8,   67.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2);
                     break;
                 case MOTOR_FRAME_TYPE_CW_X:
+                    _frame_type_string = "CW_X";
                     add_motor(AP_MOTORS_MOT_1,   22.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor(AP_MOTORS_MOT_2,   67.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2);
                     add_motor(AP_MOTORS_MOT_3,  112.5f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3);
@@ -741,14 +771,17 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 default:
                     // octa frame class does not support this frame type
+                    _frame_type_string = "UNSUPPORTED";
                     success = false;
                     break;
             } // octa frame type
             break;
 
         case MOTOR_FRAME_OCTAQUAD:
+            _frame_class_string = "OCTAQUAD";
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
+                    _frame_type_string = "PLUS";
                     add_motor(AP_MOTORS_MOT_1,    0, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor(AP_MOTORS_MOT_2,  -90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  7);
                     add_motor(AP_MOTORS_MOT_3,  180, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 5);
@@ -759,6 +792,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor(AP_MOTORS_MOT_8,  180, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  6);
                     break;
                 case MOTOR_FRAME_TYPE_X:
+                    _frame_type_string = "X";
                     add_motor(AP_MOTORS_MOT_1,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor(AP_MOTORS_MOT_2,  -45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  7);
                     add_motor(AP_MOTORS_MOT_3, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 5);
@@ -769,6 +803,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor(AP_MOTORS_MOT_8, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  6);
                     break;
                 case MOTOR_FRAME_TYPE_V:
+                    _frame_type_string = "V";
                     add_motor(AP_MOTORS_MOT_1,   45,  0.7981f, 1);
                     add_motor(AP_MOTORS_MOT_2,  -45, -0.7981f, 7);
                     add_motor(AP_MOTORS_MOT_3, -135,  1.0000f, 5);
@@ -780,6 +815,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 case MOTOR_FRAME_TYPE_H:
                     // H frame set-up - same as X but motors spin in opposite directions
+                    _frame_type_string = "H";
                     add_motor(AP_MOTORS_MOT_1,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
                     add_motor(AP_MOTORS_MOT_2,  -45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 7);
                     add_motor(AP_MOTORS_MOT_3, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  5);
@@ -790,6 +826,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor(AP_MOTORS_MOT_8, -135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 6);
                     break;
                 case MOTOR_FRAME_TYPE_CW_X:
+                    _frame_type_string = "CW_X";
                     add_motor(AP_MOTORS_MOT_1,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor(AP_MOTORS_MOT_2,   45, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2);
                     add_motor(AP_MOTORS_MOT_3,  135, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3);
@@ -801,14 +838,17 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 default:
                     // octaquad frame class does not support this frame type
+                    _frame_type_string = "UNSUPPORTED";
                     success = false;
                     break;
             }
             break;
 
         case MOTOR_FRAME_DODECAHEXA: {
+            _frame_class_string = "DODECAHEXA";
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_PLUS:
+                    _frame_type_string = "PLUS";
                     add_motor(AP_MOTORS_MOT_1,     0, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);  // forward-top
                     add_motor(AP_MOTORS_MOT_2,     0, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  2);  // forward-bottom
                     add_motor(AP_MOTORS_MOT_3,    60, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);  // forward-right-top
@@ -823,6 +863,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor(AP_MOTORS_MOT_12,  -60, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 12); // forward-left-bottom
                     break;
                 case MOTOR_FRAME_TYPE_X:
+                    _frame_type_string = "X";
                     add_motor(AP_MOTORS_MOT_1,    30, AP_MOTORS_MATRIX_YAW_FACTOR_CCW,  1); // forward-right-top
                     add_motor(AP_MOTORS_MOT_2,    30, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   2); // forward-right-bottom
                     add_motor(AP_MOTORS_MOT_3,    90, AP_MOTORS_MATRIX_YAW_FACTOR_CW,   3); // right-top
@@ -838,15 +879,18 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 default:
                     // dodeca-hexa frame class does not support this frame type
+                    _frame_type_string = "UNSUPPORTED";
                     success = false;
                     break;
             }}
             break;
 
         case MOTOR_FRAME_Y6:
+            _frame_class_string = "Y6";
             switch (frame_type) {
                 case MOTOR_FRAME_TYPE_Y6B:
                     // Y6 motor definition with all top motors spinning clockwise, all bottom motors counter clockwise
+                    _frame_type_string = "Y6B";
                     add_motor_raw(AP_MOTORS_MOT_1, -1.0f,  0.500f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  1);
                     add_motor_raw(AP_MOTORS_MOT_2, -1.0f,  0.500f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 2);
                     add_motor_raw(AP_MOTORS_MOT_3,  0.0f, -1.000f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  3);
@@ -856,6 +900,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     break;
                 case MOTOR_FRAME_TYPE_Y6F:
                     // Y6 motor layout for FireFlyY6
+                    _frame_type_string = "Y6F";
                     add_motor_raw(AP_MOTORS_MOT_1,  0.0f, -1.000f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 3);
                     add_motor_raw(AP_MOTORS_MOT_2, -1.0f,  0.500f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
                     add_motor_raw(AP_MOTORS_MOT_3,  1.0f,  0.500f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 5);
@@ -864,6 +909,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
                     add_motor_raw(AP_MOTORS_MOT_6,  1.0f,  0.500f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  6);
                     break;
                 default:
+                    _frame_type_string = "default";
                     add_motor_raw(AP_MOTORS_MOT_1, -1.0f,  0.666f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 2);
                     add_motor_raw(AP_MOTORS_MOT_2,  1.0f,  0.666f, AP_MOTORS_MATRIX_YAW_FACTOR_CW,  5);
                     add_motor_raw(AP_MOTORS_MOT_3,  1.0f,  0.666f, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 6);
@@ -876,6 +922,7 @@ void AP_MotorsMatrix::setup_motors(motor_frame_class frame_class, motor_frame_ty
 
         default:
             // matrix doesn't support the configured class
+            _frame_class_string = "UNSUPPORTED";
             success = false;
             break;
     } // switch frame_class

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -88,8 +88,6 @@ protected:
     float               _yaw_factor[AP_MOTORS_MAX_NUM_MOTORS];  // each motors contribution to yaw (normally 1 or -1)
     float               _thrust_rpyt_out[AP_MOTORS_MAX_NUM_MOTORS]; // combined roll, pitch, yaw and throttle outputs to motors in 0~1 range
     uint8_t             _test_order[AP_MOTORS_MAX_NUM_MOTORS];  // order of the motors in the test sequence
-    motor_frame_class   _last_frame_class; // most recently requested frame class (i.e. quad, hexa, octa, etc)
-    motor_frame_type    _last_frame_type; // most recently requested frame type (i.e. plus, x, v, etc)
 
     // motor failure handling
     float               _thrust_rpyt_out_filt[AP_MOTORS_MAX_NUM_MOTORS];    // filtered thrust outputs with 1 second time constant

--- a/libraries/AP_Motors/AP_MotorsMatrix.h
+++ b/libraries/AP_Motors/AP_MotorsMatrix.h
@@ -55,6 +55,9 @@ public:
     // using copter motors for forward flight
     float               get_roll_factor(uint8_t i) override { return _roll_factor[i]; }
 
+    const char*         get_frame_string() override { return _frame_class_string; }
+    const char*         get_type_string() override { return _frame_type_string; }
+
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;
@@ -92,4 +95,10 @@ protected:
     // motor failure handling
     float               _thrust_rpyt_out_filt[AP_MOTORS_MAX_NUM_MOTORS];    // filtered thrust outputs with 1 second time constant
     uint8_t             _motor_lost_index;  // index number of the lost motor
+
+    motor_frame_class   _active_frame_class; // active frame class (i.e. quad, hexa, octa, etc)
+    motor_frame_type    _active_frame_type;  // active frame type (i.e. plus, x, v, etc)
+
+    const char*         _frame_class_string = ""; // string representation of frame class
+    const char*         _frame_type_string = "";  //  string representation of frame type
 };

--- a/libraries/AP_Motors/AP_MotorsSingle.cpp
+++ b/libraries/AP_Motors/AP_MotorsSingle.cpp
@@ -175,7 +175,6 @@ void AP_MotorsSingle::output_armed_stabilizing()
 
     // combine roll, pitch and yaw on each actuator
     // front servo
-
     actuator[0] = rp_scale * roll_thrust - yaw_thrust;
     // right servo
     actuator[1] = rp_scale * pitch_thrust - yaw_thrust;

--- a/libraries/AP_Motors/AP_MotorsSingle.h
+++ b/libraries/AP_Motors/AP_MotorsSingle.h
@@ -49,6 +49,8 @@ public:
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint16_t            get_motor_mask() override;
 
+    const char* get_frame_string() override { return "SINGLE"; }
+
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_MotorsTailsitter.h
+++ b/libraries/AP_Motors/AP_MotorsTailsitter.h
@@ -33,6 +33,8 @@ public:
     //  this can be used to ensure other pwm outputs (i.e. for servos) do not conflict
     uint16_t get_motor_mask() override;
 
+    const char* get_frame_string() override { return "TAILSITTER"; }
+
 protected:
     // calculate motor outputs
     void output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_MotorsTri.h
+++ b/libraries/AP_Motors/AP_MotorsTri.h
@@ -54,6 +54,8 @@ public:
     // using copter motors for forward flight
     float               get_roll_factor(uint8_t i) override;
 
+    const char* get_frame_string() override { return "TRI"; }
+
 protected:
     // output - sends commands to the motors
     void                output_armed_stabilizing() override;

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -45,6 +45,43 @@ public:
         MOTOR_FRAME_DODECAHEXA = 12,
         MOTOR_FRAME_HELI_QUAD = 13,
     };
+
+    // return string corresponding to frame_class
+    virtual const char* get_frame_string()
+    {
+        switch (_active_frame_class) {
+            case AP_Motors::MOTOR_FRAME_QUAD:
+                return "QUAD";
+            case AP_Motors::MOTOR_FRAME_HEXA:
+                return "HEXA";
+            case AP_Motors::MOTOR_FRAME_Y6:
+                return "Y6";
+            case AP_Motors::MOTOR_FRAME_OCTA:
+                return "OCTA";
+            case AP_Motors::MOTOR_FRAME_OCTAQUAD:
+                return "OCTA_QUAD";
+            case AP_Motors::MOTOR_FRAME_HELI:
+                return "HELI";
+            case AP_Motors::MOTOR_FRAME_HELI_DUAL:
+                return "HELI_DUAL";
+            case AP_Motors::MOTOR_FRAME_HELI_QUAD:
+                return "HELI_QUAD";
+            case AP_Motors::MOTOR_FRAME_TRI:
+                return "TRI";
+            case AP_Motors::MOTOR_FRAME_SINGLE:
+                return "SINGLE";
+            case AP_Motors::MOTOR_FRAME_COAX:
+                return "COAX";
+            case AP_Motors::MOTOR_FRAME_TAILSITTER:
+                return "TAILSITTER";
+            case AP_Motors::MOTOR_FRAME_DODECAHEXA:
+                return "DODECA_HEXA";
+            case AP_Motors::MOTOR_FRAME_UNDEFINED:
+            default:
+                return "UNKNOWN";
+        }
+    };
+
     enum motor_frame_type {
         MOTOR_FRAME_TYPE_PLUS = 0,
         MOTOR_FRAME_TYPE_X = 1,
@@ -62,6 +99,50 @@ public:
         MOTOR_FRAME_TYPE_NYT_PLUS = 16, // plus frame, no differential torque for yaw
         MOTOR_FRAME_TYPE_NYT_X = 17, // X frame, no differential torque for yaw
         MOTOR_FRAME_TYPE_BF_X_REV = 18, // X frame, betaflight ordering, reversed motors
+        MOTOR_FRAME_TYPE_UNUSED
+    };
+
+    // return string corresponding to frame_type
+    const char* get_type_string()
+    {
+        switch(_active_frame_type) {
+            case MOTOR_FRAME_TYPE_PLUS:
+                return "PLUS";
+            case MOTOR_FRAME_TYPE_X:
+                return "X";
+            case MOTOR_FRAME_TYPE_V:
+                return "V";
+            case MOTOR_FRAME_TYPE_H:
+                return "H";
+            case MOTOR_FRAME_TYPE_VTAIL:
+                return "VTAIL";
+            case MOTOR_FRAME_TYPE_ATAIL:
+                return "ATAIL";
+            case MOTOR_FRAME_TYPE_PLUSREV:
+                return "PLUSREV";
+            case MOTOR_FRAME_TYPE_Y6B:
+                return "Y6B";
+            case MOTOR_FRAME_TYPE_Y6F:
+                return "Y6F";
+            case MOTOR_FRAME_TYPE_BF_X:
+                return "BF_X";
+            case MOTOR_FRAME_TYPE_DJI_X:
+                return "DJI_X";
+            case MOTOR_FRAME_TYPE_CW_X:
+                return "CW_X";
+            case MOTOR_FRAME_TYPE_I:
+                return "I";
+            case MOTOR_FRAME_TYPE_NYT_PLUS:
+                return "NYT_PLUS";
+            case MOTOR_FRAME_TYPE_NYT_X:
+                return "NYT_X";
+            case MOTOR_FRAME_TYPE_BF_X_REV:
+                return "BF_X_REV";
+            case MOTOR_FRAME_TYPE_UNUSED:
+                return "UNUSED";
+            default:
+                return "UNKNOWN";
+        }
     };
 
     // Constructor
@@ -156,7 +237,12 @@ public:
     virtual void        set_update_rate( uint16_t speed_hz ) { _speed_hz = speed_hz; }
 
     // init
-    virtual void        init(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
+    void                initialise(motor_frame_class frame_class, motor_frame_type frame_type)
+    {
+        _active_frame_class = frame_class;
+        _active_frame_type = frame_type;
+        init(frame_class, frame_type);
+    }
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
     virtual void        set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
@@ -207,6 +293,11 @@ protected:
     virtual void        rc_write_angle(uint8_t chan, int16_t angle_cd);
     virtual void        rc_set_freq(uint32_t mask, uint16_t freq_hz);
     virtual uint32_t    rc_map_mask(uint32_t mask) const;
+
+    motor_frame_class   _active_frame_class; // active frame class (i.e. quad, hexa, octa, etc)
+    motor_frame_type    _active_frame_type;  // active frame type (i.e. plus, x, v, etc)
+
+    virtual void init(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
 
     // add a motor to the motor map
     void add_motor_num(int8_t motor_num);

--- a/libraries/AP_Motors/AP_Motors_Class.h
+++ b/libraries/AP_Motors/AP_Motors_Class.h
@@ -47,40 +47,7 @@ public:
     };
 
     // return string corresponding to frame_class
-    virtual const char* get_frame_string()
-    {
-        switch (_active_frame_class) {
-            case AP_Motors::MOTOR_FRAME_QUAD:
-                return "QUAD";
-            case AP_Motors::MOTOR_FRAME_HEXA:
-                return "HEXA";
-            case AP_Motors::MOTOR_FRAME_Y6:
-                return "Y6";
-            case AP_Motors::MOTOR_FRAME_OCTA:
-                return "OCTA";
-            case AP_Motors::MOTOR_FRAME_OCTAQUAD:
-                return "OCTA_QUAD";
-            case AP_Motors::MOTOR_FRAME_HELI:
-                return "HELI";
-            case AP_Motors::MOTOR_FRAME_HELI_DUAL:
-                return "HELI_DUAL";
-            case AP_Motors::MOTOR_FRAME_HELI_QUAD:
-                return "HELI_QUAD";
-            case AP_Motors::MOTOR_FRAME_TRI:
-                return "TRI";
-            case AP_Motors::MOTOR_FRAME_SINGLE:
-                return "SINGLE";
-            case AP_Motors::MOTOR_FRAME_COAX:
-                return "COAX";
-            case AP_Motors::MOTOR_FRAME_TAILSITTER:
-                return "TAILSITTER";
-            case AP_Motors::MOTOR_FRAME_DODECAHEXA:
-                return "DODECA_HEXA";
-            case AP_Motors::MOTOR_FRAME_UNDEFINED:
-            default:
-                return "UNKNOWN";
-        }
-    };
+    virtual const char* get_frame_string() = 0;
 
     enum motor_frame_type {
         MOTOR_FRAME_TYPE_PLUS = 0,
@@ -99,51 +66,10 @@ public:
         MOTOR_FRAME_TYPE_NYT_PLUS = 16, // plus frame, no differential torque for yaw
         MOTOR_FRAME_TYPE_NYT_X = 17, // X frame, no differential torque for yaw
         MOTOR_FRAME_TYPE_BF_X_REV = 18, // X frame, betaflight ordering, reversed motors
-        MOTOR_FRAME_TYPE_UNUSED
     };
 
     // return string corresponding to frame_type
-    const char* get_type_string()
-    {
-        switch(_active_frame_type) {
-            case MOTOR_FRAME_TYPE_PLUS:
-                return "PLUS";
-            case MOTOR_FRAME_TYPE_X:
-                return "X";
-            case MOTOR_FRAME_TYPE_V:
-                return "V";
-            case MOTOR_FRAME_TYPE_H:
-                return "H";
-            case MOTOR_FRAME_TYPE_VTAIL:
-                return "VTAIL";
-            case MOTOR_FRAME_TYPE_ATAIL:
-                return "ATAIL";
-            case MOTOR_FRAME_TYPE_PLUSREV:
-                return "PLUSREV";
-            case MOTOR_FRAME_TYPE_Y6B:
-                return "Y6B";
-            case MOTOR_FRAME_TYPE_Y6F:
-                return "Y6F";
-            case MOTOR_FRAME_TYPE_BF_X:
-                return "BF_X";
-            case MOTOR_FRAME_TYPE_DJI_X:
-                return "DJI_X";
-            case MOTOR_FRAME_TYPE_CW_X:
-                return "CW_X";
-            case MOTOR_FRAME_TYPE_I:
-                return "I";
-            case MOTOR_FRAME_TYPE_NYT_PLUS:
-                return "NYT_PLUS";
-            case MOTOR_FRAME_TYPE_NYT_X:
-                return "NYT_X";
-            case MOTOR_FRAME_TYPE_BF_X_REV:
-                return "BF_X_REV";
-            case MOTOR_FRAME_TYPE_UNUSED:
-                return "UNUSED";
-            default:
-                return "UNKNOWN";
-        }
-    };
+    virtual const char* get_type_string() { return ""; }
 
     // Constructor
     AP_Motors(uint16_t loop_rate, uint16_t speed_hz = AP_MOTORS_SPEED_DEFAULT);
@@ -237,12 +163,7 @@ public:
     virtual void        set_update_rate( uint16_t speed_hz ) { _speed_hz = speed_hz; }
 
     // init
-    void                initialise(motor_frame_class frame_class, motor_frame_type frame_type)
-    {
-        _active_frame_class = frame_class;
-        _active_frame_type = frame_type;
-        init(frame_class, frame_type);
-    }
+    virtual void        init(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
 
     // set frame class (i.e. quad, hexa, heli) and type (i.e. x, plus)
     virtual void        set_frame_class_and_type(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
@@ -293,11 +214,6 @@ protected:
     virtual void        rc_write_angle(uint8_t chan, int16_t angle_cd);
     virtual void        rc_set_freq(uint32_t mask, uint16_t freq_hz);
     virtual uint32_t    rc_map_mask(uint32_t mask) const;
-
-    motor_frame_class   _active_frame_class; // active frame class (i.e. quad, hexa, octa, etc)
-    motor_frame_type    _active_frame_type;  // active frame type (i.e. plus, x, v, etc)
-
-    virtual void init(motor_frame_class frame_class, motor_frame_type frame_type) = 0;
 
     // add a motor to the motor map
     void add_motor_num(int8_t motor_num);


### PR DESCRIPTION
also adds frame_type strings

moves the get_frame_string method into the AP_Motors base class along with _last_frame_class and type, renaming them to _active_frame_class/type
adds a new non-virtual base class method initialise(class, type) which sets the active frame class/type and then calls the original pure virtual init(class, type) 
Since AP_Motors6DOF inherits from AP_MotorsMatrix, but uses a different frame class enum (sub_frame_t), for correctness the get_frame_string method is virtual and overridden by AP_Motors6DOF, although this method is currently unused by Sub.
When testing this, I noticed that copter tailsitter setup in quadplane was susceptible to configuration errors involving frame classes not supported by AP_MotorsMatrix;  these now result in a call to config_error.
Also, the gcs().send_text calls in QuadPlane::setup occur before the GCS is connected; changed these to ::printf since they were apparently of no value to the user.
Also added a quadplane frame class/type message to the log similar to Copter's.