### PR TITLE
Plane: move tailsitter_check_input out of RC_Channel

### DIFF
--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -36,8 +36,11 @@ void ModeQStabilize::update()
 }
 
 // set the desired roll and pitch for a tailsitter
-void ModeQStabilize::set_tailsitter_roll_pitch(const float roll_input, const float pitch_input)
+void ModeQStabilize::set_tailsitter_roll_pitch(float roll_input, const float pitch_input)
 {
+    float yaw_input;
+    plane.quadplane.get_pilot_input_roll_yaw(roll_input, yaw_input);
+
     // separate limit for roll, if set
     if (plane.quadplane.tailsitter.max_roll_angle > 0) {
         // roll param is in degrees not centidegrees

--- a/ArduPlane/qautotune.cpp
+++ b/ArduPlane/qautotune.cpp
@@ -29,7 +29,9 @@ float QAutoTune::get_pilot_desired_climb_rate_cms(void) const
 
 void QAutoTune::get_pilot_desired_rp_yrate_cd(float &des_roll_cd, float &des_pitch_cd, float &yaw_rate_cds)
 {
-    if (plane.channel_roll->get_control_in() == 0 && plane.channel_pitch->get_control_in() == 0) {
+    float roll_input, yaw_input;
+    plane.quadplane.get_pilot_input_roll_yaw(roll_input, yaw_input);
+    if (is_zero(roll_input) && plane.channel_pitch->get_control_in() == 0) {
         des_roll_cd = 0;
         des_pitch_cd = 0;
     } else {

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1193,7 +1193,8 @@ void QuadPlane::get_pilot_desired_lean_angles(float &roll_out_cd, float &pitch_o
     }
 
     // fetch roll and pitch inputs
-    roll_out_cd = plane.channel_roll->get_control_in();
+    float yaw_input;
+    get_pilot_input_roll_yaw(roll_out_cd, yaw_input);
     pitch_out_cd = plane.channel_pitch->get_control_in();
 
     // limit max lean angle, always allow for 10 degrees
@@ -1201,7 +1202,7 @@ void QuadPlane::get_pilot_desired_lean_angles(float &roll_out_cd, float &pitch_o
 
     // scale roll and pitch inputs to ANGLE_MAX parameter range
     float scaler = angle_max_cd/4500.0;
-    roll_out_cd *= scaler;
+    roll_out_cd *= angle_max_cd;
     pitch_out_cd *= scaler;
 
     // apply circular limit
@@ -1506,7 +1507,11 @@ float QuadPlane::get_pilot_input_yaw_rate_cds(void) const
         // must have a non-zero max yaw rate for scaling to work
         max_rate = (yaw_rate_max < 1.0f) ? 1 : yaw_rate_max;
     }
-    return plane.channel_rudder->get_control_in() * max_rate / 45;
+
+    // if tailsitter with plane mode inputs, use -roll for yaw unless in QACRO mode
+    float roll_input, yaw_input;
+    get_pilot_input_roll_yaw(roll_input, yaw_input);
+    return yaw_input * max_rate * 100;
 }
 
 /*

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -126,13 +126,13 @@ public:
     bool _is_vectored;
 
     // return true when flying a tailsitter in VTOL
-    bool tailsitter_active(void);
+    bool tailsitter_active(void) const;
     
     // create outputs for tailsitters
     void tailsitter_output(void);
 
     // handle different tailsitter input types
-    void tailsitter_check_input(void);
+    void get_pilot_input_roll_yaw(float &roll_input, float &yaw_input) const;
     
     // check if we have completed transition to fixed wing
     bool tailsitter_transition_fw_complete(void);

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -206,9 +206,6 @@ void Plane::read_radio()
 
     rudder_arm_disarm_check();
 
-    // potentially swap inputs for tailsitters
-    quadplane.tailsitter_check_input();
-
     // check for transmitter tuning changes
     tuning.check_input(control_mode->mode_number());
 }


### PR DESCRIPTION
Move handling of tailsitter.input_type from class RC_Channel to quadplane code since it is only relevant to ModeQStabilize::update() and QuadPlane::get_pilot_input_yaw_rate_cds().

This is preferable to tailsitter_input_check() since swapping RC_Channel control_in values creates confusion because the results of norm_input and get_control_in don't return values for the same channel.