### PR TITLE
Plane: fix tailsitter_check_input bug

### DIFF
--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -133,7 +133,7 @@ public:
 
     // handle different tailsitter input types
     void tailsitter_check_input(void);
-    
+
     // check if we have completed transition to fixed wing
     bool tailsitter_transition_fw_complete(void);
 

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -54,6 +54,7 @@ public:
     float       norm_input_ignore_trim() const;
 
     uint8_t     percent_input() const;
+    int16_t     pwm_to_angle() const;
     int16_t     pwm_to_range() const;
     int16_t     pwm_to_range_dz(uint16_t dead_zone) const;
 
@@ -310,7 +311,6 @@ private:
     uint16_t override_value;
     uint32_t last_override_time;
 
-    int16_t pwm_to_angle() const;
     int16_t pwm_to_angle_dz(uint16_t dead_zone) const;
 
     // Structure used to detect and debounce switch changes


### PR DESCRIPTION
modify tailsitter_check_input to swap radio_in values and update control_in for aileron and rudder channels.
This ensures that norm_input and relatives will also return the expected values based on tailsitter.input_type