### PR TITLE
Pr cleanup norm input

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -98,7 +98,7 @@ void AP_Mount_Backend::control(int32_t pitch_or_lat, int32_t roll_or_lon, int32_
     }
 }
 
-void AP_Mount_Backend::rate_input_rad(float &out, const RC_Channel *chan, float min, float max) const
+void AP_Mount_Backend::rate_input_rad(float &out, RC_Channel *chan, float min, float max) const
 {
     if ((chan == nullptr) || (chan->get_radio_in() == 0)) {
         return;
@@ -110,9 +110,9 @@ void AP_Mount_Backend::rate_input_rad(float &out, const RC_Channel *chan, float 
 // update_targets_from_rc - updates angle targets using input from receiver
 void AP_Mount_Backend::update_targets_from_rc()
 {
-    const RC_Channel *roll_ch = rc().channel(_state._roll_rc_in - 1);
-    const RC_Channel *tilt_ch = rc().channel(_state._tilt_rc_in - 1);
-    const RC_Channel *pan_ch = rc().channel(_state._pan_rc_in - 1);
+    RC_Channel *roll_ch = rc().channel(_state._roll_rc_in - 1);
+    RC_Channel *tilt_ch = rc().channel(_state._tilt_rc_in - 1);
+    RC_Channel *pan_ch = rc().channel(_state._pan_rc_in - 1);
 
     // if joystick_speed is defined then pilot input defines a rate of change of the angle
     if (_frontend._joystick_speed) {

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -124,7 +124,7 @@ protected:
 
 private:
 
-    void rate_input_rad(float &out, const RC_Channel *ch, float min, float max) const;
+    void rate_input_rad(float &out, RC_Channel *ch, float min, float max) const;
 };
 
 #endif // HAL_MOUNT_ENABLED

--- a/libraries/AP_Winch/AP_Winch_Backend.cpp
+++ b/libraries/AP_Winch/AP_Winch_Backend.cpp
@@ -19,7 +19,7 @@ void AP_Winch_Backend::init()
 void AP_Winch_Backend::read_pilot_desired_rate()
 {
     // fail if no input channel defined
-    const RC_Channel *rc_input = rc().find_channel_for_option(RC_Channel::AUX_FUNC::WINCH_CONTROL);
+    RC_Channel *rc_input = rc().find_channel_for_option(RC_Channel::AUX_FUNC::WINCH_CONTROL);
     if (rc_input == nullptr) {
         return;
     }

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -27,6 +27,7 @@ public:
     uint16_t    get_range() const { return high_in; }
     void        set_angle(uint16_t angle);
     bool        get_reverse(void) const;
+    void        set_reverse(bool);
     void        set_default_dead_zone(int16_t dzone);
     uint16_t    get_dead_zone(void) const { return dead_zone; }
 
@@ -35,6 +36,13 @@ public:
 
     // read input from hal.rcin - create a control_in value
     bool        update(void);
+
+    // update converted input values if new data is available
+    void        update_norm_in(void);
+    void        update_norm_in_no_dz(void);
+    void        update_control_in_no_dz(void);
+
+    float       calc_normalized_input(int16_t dz);
     void        recompute_pwm_no_deadzone();
 
     // calculate an angle given dead_zone and trim. This is used by the quadplane code
@@ -43,11 +51,11 @@ public:
 
     // return a normalised input for a channel, in range -1 to 1,
     // centered around the channel trim. Ignore deadzone.
-    float       norm_input() const;
+    float       norm_input();
 
     // return a normalised input for a channel, in range -1 to 1,
     // centered around the channel trim. Take into account the deadzone
-    float       norm_input_dz() const;
+    float       norm_input_dz();
 
     // return a normalised input for a channel, in range -1 to 1,
     // ignores trim and deadzone
@@ -63,7 +71,12 @@ public:
     bool       in_trim_dz() const;
 
     int16_t    get_radio_in() const { return radio_in;}
-    void       set_radio_in(int16_t val) {radio_in = val;}
+    void       set_radio_in(int16_t val) {
+                radio_in = val;
+                norm_in_stale = true;
+                norm_in_no_dz_stale = true;
+                control_in_no_dz_stale = true;
+    }
 
     int16_t    get_control_in() const { return control_in;}
     void       set_control_in(int16_t val) { control_in = val;}
@@ -75,7 +88,7 @@ public:
     int16_t    stick_mixing(const int16_t servo_in);
 
     // get control input with zero deadzone
-    int16_t    get_control_in_zero_dz(void) const;
+    int16_t    get_control_in_zero_dz(void);
 
     int16_t    get_radio_min() const {return radio_min.get();}
     void       set_radio_min(int16_t val) { radio_min = val;}
@@ -313,6 +326,15 @@ private:
 
     // value generated from PWM normalised to configured scale
     int16_t    control_in;
+
+    bool       control_in_no_dz_stale;
+    int16_t    control_in_no_dz;
+
+    bool       norm_in_stale;
+    float      norm_in;
+
+    bool       norm_in_no_dz_stale;
+    float      norm_in_no_dz;
 
     AP_Int16    radio_min;
     AP_Int16    radio_trim;

--- a/libraries/RC_Channel/tests/test_RC_input.cpp
+++ b/libraries/RC_Channel/tests/test_RC_input.cpp
@@ -1,0 +1,146 @@
+/*
+ *       Unit Tests for RC_Channel library.
+ *       Based on original example by Jason Short. 2010
+ */
+
+#include <AP_gtest.h>
+
+#include <AP_HAL/AP_HAL.h>
+#include <RC_Channel/RC_Channel.h>
+
+// copied from ArduPlane-stable (4.0.9)
+float original_norm_input(uint16_t min, uint16_t max, uint16_t trim, uint16_t in, bool reversed)
+{
+    float ret;
+    int16_t reverse_mul = (reversed?-1:1);
+    if (in < trim) {
+        if (min >= trim) {
+            return 0.0f;
+        }
+        ret = reverse_mul * (float)(in - trim) / (float)(trim - min);
+    } else {
+        if (max <= trim) {
+            return 0.0f;
+        }
+        ret = reverse_mul * (float)(in - trim) / (float)(max  - trim);
+    }
+    return constrain_float(ret, -1.0f, 1.0f);
+}
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+class RC_Channel_Example : public RC_Channel
+{
+};
+
+class RC_Channels_Example : public RC_Channels
+{
+public:
+
+    RC_Channel_Example obj_channels[NUM_RC_CHANNELS];
+
+    RC_Channel_Example *channel(const uint8_t chan) override {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+
+protected:
+
+    int8_t flight_mode_channel_number() const override { return 5; }
+
+private:
+
+};
+
+#define RC_CHANNELS_SUBCLASS RC_Channels_Example
+#define RC_CHANNEL_SUBCLASS RC_Channel_Example
+
+#include <RC_Channel/RC_Channels_VarInfo.h>
+
+static RC_Channels_Example rc_channels;
+
+TEST(RCInputTest, norm_input_set_radio_in)
+{
+    rc().init();
+
+    const uint16_t pwm_min = 900;
+    const uint16_t pwm_trim = 1500;
+    const uint16_t pwm_max = 2100;
+
+    RC_Channel chan = *rc().channel(CH_1);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(pwm_trim);
+    chan.set_radio_max(pwm_max);
+
+    // this compiles and runs but get_reverse() always returns zero
+//    float rev_f = reversed ? 1:0;
+//
+//    const AP_Param::GroupInfo* const *rc1_GroupInfo = &rc_channels.var_info[0].group_info;
+//    if (!AP_Param::set_object_value(&rc_channels, *rc1_GroupInfo, "REVERSED", rev_f)) {
+//        printf("WARNING: AP_Param::set object value \"%s::%s\" Failed.\n",
+//                rc_channels.var_info->name, "REVERSED");
+//    }
+//    rev_f = chan.get_reverse();
+//    printf("RC1_REVERSED: %d\n", chan.get_reverse());
+
+    const float accuracy = 1.0e-7f;
+    float orig_result;
+    float new_result;
+    
+    // test norm_input over the pwm range [pwm_min, pwm_max]
+    bool reversed = true;
+    do {        
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        printf("reversed: %d\n", reversed);
+        for (uint16_t pwm=pwm_min; pwm<=pwm_max; pwm+=100) {
+            orig_result = original_norm_input(pwm_min, pwm_max, pwm_trim, pwm, reversed);
+            chan.set_radio_in(pwm);
+            new_result = chan.norm_input();
+    //        printf("pwm: %4i, orig: %10.7f, new: %10.7f\n", pwm, orig_result, new_result);
+            EXPECT_NEAR(new_result, orig_result, accuracy);
+        }
+    } while (!reversed);
+}
+
+TEST(RCInputTest, norm_input_update)
+{
+    const uint16_t pwm_min = 900;
+    const uint16_t pwm_trim = 1500;
+    const uint16_t pwm_max = 2100;
+
+    RC_Channel chan = *rc().channel(CH_1);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(pwm_trim);
+    chan.set_radio_max(pwm_max);
+
+    // no set_reversed in RC_Channel
+    bool reversed = chan.get_reverse();
+
+    const float accuracy = 1.0e-7f;
+    float orig_result;
+    float new_result;
+    
+    reversed = true;
+    do {        
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        printf("reversed: %d\n", reversed);
+        // test norm_input over the pwm range [pwm_min, pwm_max]
+        for (uint16_t pwm=pwm_min; pwm<=pwm_max; pwm+=100) {
+            orig_result = original_norm_input(pwm_min, pwm_max, pwm_trim, pwm, reversed);
+
+            chan.set_override(pwm, 0);
+            chan.update();
+            new_result = chan.norm_input();
+    //        printf("pwm: %4i, orig: %10.7f, new: %10.7f\n", pwm, orig_result, new_result);
+            EXPECT_NEAR(new_result, orig_result, accuracy);
+        }
+    } while (!reversed);
+}
+
+AP_GTEST_MAIN()

--- a/libraries/RC_Channel/tests/wscript
+++ b/libraries/RC_Channel/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap'
+    )


### PR DESCRIPTION
get_control_in_zero_dz, norm_input and relatives are called at 300 or 400 Hz in copter, plane and quadplane, recomputing values based on radio_in
Since radio_in updates at 50Hz, this wastes cpu cycles.

This change uses the same strategy as that for updating control_in: only when a new value is read for radio_in.
It adds 3 boolean state variables to RC_Channel and makes the RC_Channel normalized input methods non-const.

An alternative to keep the input methods const would be to delete the new state variables and unconditionally compute the 3 input values in  RC_Channel::update(). This would have minimal cpu impact since the potentially unused results are only computed at 50Hz.

another alternative might be to add a channel type of normalized in addition to angle and range, but some channels are used as more than one type.

```
Binary           text            data         bss            total
---------------  --------------  -----------  -------------  --------------
antennatracker   20 (+0.0027%)   0 (0.0000%)  -4 (-0.0020%)  16 (+0.0017%)
arduplane        128 (+0.0128%)  0 (0.0000%)  0 (0.0000%)    128 (+0.0107%)
arducopter       36 (+0.0037%)   0 (0.0000%)  4 (+0.0020%)   40 (+0.0035%)
ardusub          92 (+0.0105%)   0 (0.0000%)  -4 (-0.0020%)  88 (+0.0082%)
blimp            28 (+0.0041%)   0 (0.0000%)  4 (+0.0020%)   32 (+0.0036%)
ardurover        4 (+0.0005%)    0 (0.0000%)  4 (+0.0020%)   8 (+0.0007%)
arducopter-heli  24 (+0.0025%)   0 (0.0000%)  0 (0.0000%)    24 (+0.0021%)
```