### PR TITLE
RC_Channel::set_control_in() - Maintain consistency between control_in and norm_in 

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -381,6 +381,10 @@ const struct LogStructure Plane::log_structure[] = {
 // @Field: Ast: Q assist active state
     { LOG_QTUN_MSG, sizeof(QuadPlane::log_QControl_Tuning),
       "QTUN", "QffffffeccffBB", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Sscl,Trn,Ast", "s----mmmnn----", "F----00000-0--" },
+      
+//@LoggerMessage: RCTL
+      { LOG_RCTL_MSG, sizeof(QuadPlane::log_RCTL),
+        "RCTL", "QBhf", "TimeUS,c,ctl_in,norm_in", "s#--", "F---"},
 
 // @LoggerMessage: PIQR,PIQP,PIQY,PIQA
 // @Description: QuadPlane Proportional/Integral/Derivative gain values for Roll/Pitch/Yaw/Z

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -6,7 +6,7 @@
 #define TRUE 1
 #define FALSE 0
 
-#define DEBUG 0
+//#define DEBUG 0
 #define SERVO_MAX 4500  // This value represents 45 degrees and is just an
                         // arbitrary representation of servo max travel.
 
@@ -97,6 +97,7 @@ enum log_messages {
     LOG_CMDA_MSG,
     LOG_CMDS_MSG,
     LOG_CMDH_MSG,
+    LOG_RCTL_MSG,
 };
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2143,6 +2143,15 @@ void QuadPlane::update(void)
             if (now - last_ctrl_log_ms > 100) {
                 last_ctrl_log_ms = now;
                 attitude_control->control_monitor_log();
+
+                // if set_control_in has been called log the modified values
+//                for (uint8_t cnum=0; cnum<rc().get_valid_channel_count(); cnum++) {
+                for (uint8_t cnum=0; cnum<4; cnum++) {
+                    RC_Channel chan = *rc().channel(cnum);
+                    if (true || chan.control_override) {
+                        Log_Write_RCTL(chan, cnum+1);
+                    }
+                }
             }
         }
         // log QTUN at 25 Hz if motors are active, or have been active in the last quarter second
@@ -2152,6 +2161,18 @@ void QuadPlane::update(void)
         }
     }
 
+}
+
+void QuadPlane::Log_Write_RCTL(RC_Channel &chan, uint8_t cnum)
+{
+    struct log_RCTL pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_RCTL_MSG),
+        time_us : AP_HAL::micros64(),
+        chan    : cnum,
+        ctl_in  : chan.get_control_in(),
+        norm_in : chan.norm_input()
+    };
+    plane.logger.WriteBlock(&pkt, sizeof(pkt));
 }
 
 /*

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -176,6 +176,14 @@ public:
         uint8_t  assist;
     };
 
+    struct PACKED log_RCTL {
+        LOG_PACKET_HEADER;
+        uint64_t time_us;
+        uint8_t  chan;
+        int16_t  ctl_in;
+        float    norm_in;
+    };
+    
     MAV_TYPE get_mav_type(void) const;
 
     enum Q_ASSIST_STATE_ENUM {
@@ -288,6 +296,7 @@ private:
     bool should_relax(void);
     void motors_output(bool run_rate_controller = true);
     void Log_Write_QControl_Tuning();
+    void Log_Write_RCTL(RC_Channel &chan, uint8_t cnum);
     float landing_descent_rate_cms(float height_above_ground) const;
     
     // setup correct aux channels for frame class

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -147,6 +147,7 @@ bool RC_Channel::get_reverse(void) const
  */
 void RC_Channel::set_control_in(int16_t val) 
 { 
+    control_override = true;
     control_in = val;
     control_in_no_dz = val;
 
@@ -176,6 +177,7 @@ void RC_Channel::_update(){
     // norm_in and norm_in_no_dz do not depend on channel type
     norm_in = calc_normalized_input(radio_in, dead_zone);
     norm_in_no_dz = calc_normalized_input(radio_in, 0);
+    control_override = false;
 }
 
 // read input from hal.rcin or overrides

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -14,6 +14,7 @@ class RC_Channel {
 public:
     friend class SRV_Channels;
     friend class RC_Channels;
+    friend class RC_Channel_Test;
     // Constructor
     RC_Channel(void);
 
@@ -33,8 +34,13 @@ public:
     // get the center stick position expressed as a control_in value
     int16_t     get_control_mid() const;
 
-    // read input from hal.rcin - create a control_in value
+    // read input from hal.rcin and update control_in and norm_in values
     bool        update(void);
+    // update control_in and norm_in values
+    void        _update();
+
+    float       calc_normalized_input(int16_t pwm, int16_t dz);
+    float       calc_normalized_input_ignore_trim(int16_t pwm, int16_t dz);
     void        recompute_pwm_no_deadzone();
 
     // calculate an angle given dead_zone and trim. This is used by the quadplane code
@@ -43,11 +49,11 @@ public:
 
     // return a normalised input for a channel, in range -1 to 1,
     // centered around the channel trim. Ignore deadzone.
-    float       norm_input() const;
+    float       norm_input() const { return norm_in_no_dz; }
 
     // return a normalised input for a channel, in range -1 to 1,
     // centered around the channel trim. Take into account the deadzone
-    float       norm_input_dz() const;
+    float       norm_input_dz() const { return norm_in; }
 
     // return a normalised input for a channel, in range -1 to 1,
     // ignores trim and deadzone
@@ -57,16 +63,19 @@ public:
     int16_t     pwm_to_range() const;
     int16_t     pwm_to_range_dz(uint16_t dead_zone) const;
 
+    int16_t     range_to_pwm_no_dz(int16_t rng_val) const;
+    int16_t     angle_to_pwm_no_dz(int16_t c_in) const;
+
     static const struct AP_Param::GroupInfo var_info[];
 
     // return true if input is within deadzone of trim
     bool       in_trim_dz() const;
 
     int16_t    get_radio_in() const { return radio_in;}
-    void       set_radio_in(int16_t val) {radio_in = val;}
+    void       set_radio_in(int16_t val);
 
     int16_t    get_control_in() const { return control_in;}
-    void       set_control_in(int16_t val) { control_in = val;}
+    void       set_control_in(int16_t val);
 
     void       clear_override();
     void       set_override(const uint16_t v, const uint32_t timestamp_ms);
@@ -75,7 +84,7 @@ public:
     int16_t    stick_mixing(const int16_t servo_in);
 
     // get control input with zero deadzone
-    int16_t    get_control_in_zero_dz(void) const;
+    int16_t    get_control_in_zero_dz(void) const { return control_in_no_dz; }
 
     int16_t    get_radio_min() const {return radio_min.get();}
     void       set_radio_min(int16_t val) { radio_min = val;}
@@ -313,6 +322,10 @@ private:
 
     // value generated from PWM normalised to configured scale
     int16_t    control_in;
+    int16_t    control_in_no_dz;
+
+    float      norm_in;
+    float      norm_in_no_dz;
 
     AP_Int16    radio_min;
     AP_Int16    radio_trim;

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -104,6 +104,7 @@ public:
     ChannelType get_type(void) const { return type_in; }
 
     AP_Int16    option; // e.g. activate EPM gripper / enable fence
+    bool        control_override;
 
     // auxiliary switch support
     void init_aux();

--- a/libraries/RC_Channel/tests/test_RC_input.cpp
+++ b/libraries/RC_Channel/tests/test_RC_input.cpp
@@ -1,0 +1,428 @@
+/*
+ *       Unit Tests for RC_Channel library.
+ *       Based on original example by Jason Short. 2010
+ */
+
+#include <AP_gtest.h>
+
+#include <AP_HAL/AP_HAL.h>
+#include <RC_Channel/RC_Channel.h>
+
+//#define DEBUG
+#ifdef DEBUG
+#define  DEBUG_PRINTF(fmt, ...)  printf(fmt, __VA_ARGS__);
+#else
+#define DEBUG_PRINTF(fmt, ...)    /* Do nothing */
+#endif
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+class RC_Channel_Test : public RC_Channel
+{
+public:
+    void set_reverse(bool v) { reversed.set(v); }
+    void set_dead_zone(uint16_t v) { dead_zone.set(v); }
+};
+
+class RC_Channels_Test : public RC_Channels
+{
+public:
+
+    RC_Channel_Test obj_channels[NUM_RC_CHANNELS];
+
+    RC_Channel_Test *channel(const uint8_t chan) override {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+
+protected:
+
+    int8_t flight_mode_channel_number() const override { return 5; }
+
+private:
+
+};
+
+#define RC_CHANNELS_SUBCLASS RC_Channels_Test
+#define RC_CHANNEL_SUBCLASS RC_Channel_Test
+
+#include <RC_Channel/RC_Channels_VarInfo.h>
+
+static RC_Channels_Test rc_channels;
+
+// Use source code from stable release of ArduPlane to define correct behavior
+class GoldStandard
+{
+public:
+    // copied from ArduPlane-stable (4.0.9)
+    static float norm_input(int16_t radio_min, int16_t radio_max,
+                                     int16_t radio_trim, int16_t radio_in, bool reversed)
+    {
+        float ret;
+        int16_t reverse_mul = (reversed?-1:1);
+        if (radio_in < radio_trim) {
+            if (radio_min >= radio_trim) {
+                return 0.0f;
+            }
+            ret = reverse_mul * (float)(radio_in - radio_trim) / (float)(radio_trim - radio_min);
+        } else {
+            if (radio_max <= radio_trim) {
+                return 0.0f;
+            }
+            ret = reverse_mul * (float)(radio_in - radio_trim) / (float)(radio_max  - radio_trim);
+        }
+        return constrain_float(ret, -1.0f, 1.0f);
+    }
+
+    static float norm_input_dz(int16_t dead_zone, int16_t radio_min, int16_t radio_max,
+                                        int16_t radio_trim, int16_t radio_in, bool reversed)
+    {
+        int16_t dz_min = radio_trim - dead_zone;
+        int16_t dz_max = radio_trim + dead_zone;
+        float ret;
+        int16_t reverse_mul = (reversed?-1:1);
+        if (radio_in < dz_min && dz_min > radio_min) {
+            ret = reverse_mul * (float)(radio_in - dz_min) / (float)(dz_min - radio_min);
+        } else if (radio_in > dz_max && radio_max > dz_max) {
+            ret = reverse_mul * (float)(radio_in - dz_max) / (float)(radio_max  - dz_max);
+        } else {
+            ret = 0;
+        }
+        return constrain_float(ret, -1.0f, 1.0f);
+    }
+
+    static int16_t pwm_to_angle_dz_trim(uint16_t _dead_zone, uint16_t _trim, int16_t radio_in,
+                                        int16_t radio_min, int16_t radio_max, int16_t high_in, bool reversed)
+    {
+        int16_t radio_trim_high = _trim + _dead_zone;
+        int16_t radio_trim_low  = _trim - _dead_zone;
+
+        int16_t reverse_mul = (reversed?-1:1);
+
+        // don't allow out of range values
+        int16_t r_in = constrain_int16(radio_in, radio_min, radio_max);
+
+        if (r_in > radio_trim_high && radio_max != radio_trim_high) {
+            return reverse_mul * ((int32_t)high_in * (int32_t)(r_in - radio_trim_high)) / (int32_t)(radio_max  - radio_trim_high);
+        } else if (r_in < radio_trim_low && radio_trim_low != radio_min) {
+            return reverse_mul * ((int32_t)high_in * (int32_t)(r_in - radio_trim_low)) / (int32_t)(radio_trim_low - radio_min);
+        } else {
+            return 0;
+        }
+    }
+
+    static int16_t pwm_to_range_dz(uint16_t _dead_zone, int16_t radio_in, int16_t radio_min,
+                                   int16_t radio_max, int16_t high_in, bool reversed)
+    {
+        int16_t r_in = constrain_int16(radio_in, radio_min, radio_max);
+
+        if (reversed) {
+            r_in = radio_max - (r_in - radio_min);
+        }
+
+        int16_t radio_trim_low  = radio_min + _dead_zone;
+
+        if (r_in > radio_trim_low) {
+            return (((int32_t)(high_in) * (int32_t)(r_in - radio_trim_low)) / (int32_t)(radio_max - radio_trim_low));
+        }
+        return 0;
+    }
+
+};
+
+const int16_t pwm_min = 900;
+const int16_t pwm_trim = 1500;
+const int16_t pwm_max = 2100;
+const uint16_t dead_zone = 30;
+const float accuracy = 1.0e-7f;
+
+// Test norm_input and norm_input_dz with set_radio_in(pwm)
+TEST(RCInputTest, norm_input_set_radio_in)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(pwm_trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+
+    float orig_norm_input;
+    float new_norm_input;
+    float orig_norm_input_dz;
+    float new_norm_input_dz;
+
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d, dead_zone: %d\n", reversed, dead_zone);
+        // compare with original norm_input over the pwm range [pwm_min, pwm_max]
+        for (int16_t pwm=pwm_min; pwm<=pwm_max; pwm+=1) {
+            orig_norm_input = GoldStandard::norm_input(pwm_min, pwm_max, pwm_trim, pwm, reversed);
+            orig_norm_input_dz = GoldStandard::norm_input_dz(dead_zone, pwm_min, pwm_max, pwm_trim, pwm, reversed);
+            chan.set_radio_in(pwm);
+            new_norm_input = chan.norm_input();
+            new_norm_input_dz = chan.norm_input_dz();
+            DEBUG_PRINTF("pwm: %4i, orig: %10.7f, new: %10.7f\n", pwm, orig_norm_input_dz, new_norm_input_dz);
+            EXPECT_NEAR(new_norm_input, orig_norm_input, accuracy);
+            EXPECT_NEAR(new_norm_input_dz, orig_norm_input_dz, accuracy);
+        }
+        // test out of range pwm inputs
+        float rmin = reversed ? 1 : -1;
+        float rmax = -rmin;
+        chan.set_radio_in(pwm_min - 100);
+        EXPECT_NEAR(chan.norm_input(), rmin, accuracy);
+        chan.set_radio_in(pwm_max + 100);
+        EXPECT_NEAR(chan.norm_input(), rmax, accuracy);
+
+        // test out of range trim values
+        chan.set_radio_in(pwm_min);
+        chan.set_radio_trim(pwm_min - 100);
+        EXPECT_NEAR(chan.norm_input(), rmin, accuracy);
+        chan.set_radio_trim(pwm_max + 100);
+        EXPECT_NEAR(chan.norm_input(), rmin, accuracy);
+
+        chan.set_radio_trim(pwm_min - 100);
+        chan.set_radio_in(pwm_max);
+        EXPECT_NEAR(chan.norm_input(), rmax, accuracy);
+        chan.set_radio_trim(pwm_max);
+        chan.set_radio_in(pwm_max + 100);
+        EXPECT_NEAR(chan.norm_input(), 0, accuracy);
+        chan.set_radio_trim(pwm_trim);
+    } while (!reversed);
+
+}
+
+// Test norm_input and norm_input_dz with set_override(pwm) followed by update()
+TEST(RCInputTest, norm_input_update)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(pwm_trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+
+    float orig_norm_input;
+    float new_norm_input;
+    float orig_norm_input_dz;
+    float new_norm_input_dz;
+
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d\n", reversed);
+        // compare with original norm_input over the pwm range [pwm_min, pwm_max]
+        for (int16_t pwm=pwm_min; pwm<=pwm_max; pwm+=1) {
+            orig_norm_input = GoldStandard::norm_input(pwm_min, pwm_max, pwm_trim, pwm, reversed);
+            orig_norm_input_dz = GoldStandard::norm_input_dz(dead_zone, pwm_min, pwm_max, pwm_trim, pwm, reversed);
+
+            chan.set_override(pwm, 0);
+            chan.update();
+            new_norm_input = chan.norm_input();
+            new_norm_input_dz = chan.norm_input_dz();
+            DEBUG_PRINTF("pwm: %4i, orig: %10.7f, new: %10.7f\n", pwm, orig_norm_input, new_norm_input);
+            EXPECT_NEAR(new_norm_input, orig_norm_input, accuracy);
+            EXPECT_NEAR(new_norm_input_dz, orig_norm_input_dz, accuracy);
+        }
+        // test out of range inputs
+        float rmin = reversed ? 1 : -1;
+        float rmax = -rmin;
+        chan.set_radio_in(pwm_min - 100);
+        EXPECT_NEAR(chan.norm_input_dz(), rmin, accuracy);
+        chan.set_radio_in(pwm_max + 100);
+        EXPECT_NEAR(chan.norm_input_dz(), rmax, accuracy);
+    } while (!reversed);
+}
+
+// Test control_input and control_input_no_dz with set_override(pwm) followed by update()
+// for RC_CHANNEL_TYPE_RANGE
+TEST(RCInputTest, control_input_range)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(pwm_trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+    int16_t high_in = 1000;
+    // sets high_in
+    chan.set_range(high_in);
+
+    // test RC_CHANNEL_TYPE_RANGE
+    // control_in maps [pwm_min, pwm_max] to [0, high_in]
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d\n", reversed);
+        // test over the pwm range [pwm_min, pwm_max]
+        for (int16_t pwm=pwm_min; pwm<=pwm_max; pwm+=1) {
+            int16_t tc_in = GoldStandard::pwm_to_range_dz(dead_zone, pwm, pwm_min, pwm_max, high_in, reversed);
+            int16_t tc_in_no_dz = GoldStandard::pwm_to_range_dz(0, pwm, pwm_min, pwm_max, high_in, reversed);
+            chan.set_override(pwm, 0);
+            chan.update();
+            int16_t c_in = chan.get_control_in();
+            int16_t c_in_no_dz = chan.get_control_in_zero_dz();
+            DEBUG_PRINTF("pwm: %4i, tc_in: %d, c_in: %d\n", pwm, tc_in, c_in);
+            EXPECT_EQ(c_in, tc_in);
+            EXPECT_EQ(c_in_no_dz, tc_in_no_dz);
+        }
+        // test out of range inputs
+        int16_t rmin = reversed ? high_in : 0;
+        int16_t rmax = high_in - rmin;
+        chan.set_radio_in(pwm_min - 100);
+        EXPECT_EQ(chan.get_control_in(), rmin);
+        chan.set_radio_in(pwm_max + 100);
+        EXPECT_EQ(chan.get_control_in(), rmax);
+    } while (!reversed);
+
+}
+
+// Test control_input and control_input_no_dz with set_override(pwm) followed by update()
+// for RC_CHANNEL_TYPE_ANGLE
+TEST(RCInputTest, control_input_angle)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    // for angle type channels, trim is expected to be near (pwm_max-pwm_min)/2
+    int16_t trim = 1533;
+
+    int16_t high_in = 4500;
+    // sets high_in
+    chan.set_angle(high_in);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+
+    // test RC_CHANNEL_TYPE_ANGLE
+    // control_in maps [pwm_min, pwm_max] to [-high_in, high_in]
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d\n", reversed);
+        // test over the pwm range [pwm_min, pwm_max]
+        for (int16_t pwm=pwm_min; pwm<=pwm_max; pwm+=1) {
+            int16_t tc_in = GoldStandard::pwm_to_angle_dz_trim(dead_zone, trim, pwm, pwm_min, pwm_max, high_in, reversed);
+            int16_t tc_in_no_dz = GoldStandard::pwm_to_angle_dz_trim(0, trim, pwm, pwm_min, pwm_max, high_in, reversed);
+            chan.set_override(pwm, 0);
+            chan.update();
+            int16_t c_in = chan.get_control_in();
+            int16_t c_in_no_dz = chan.get_control_in_zero_dz();
+            DEBUG_PRINTF("pwm: %4i, tc_in: %d, c_in: %d\n", pwm, tc_in, c_in);
+            EXPECT_EQ(c_in, tc_in);
+            EXPECT_EQ(c_in_no_dz, tc_in_no_dz);
+        }
+        // test out of range inputs
+        float rmin = reversed ? high_in : -high_in;
+        float rmax = -rmin;
+        chan.set_radio_in(pwm_min - 100);
+        EXPECT_EQ(chan.get_control_in(), rmin);
+        chan.set_radio_in(pwm_max + 100);
+        EXPECT_EQ(chan.get_control_in(), rmax);
+    } while (!reversed);
+
+}
+
+// Verify that set_control_in() results in correct values for norm_in
+// for channels of type RC_CHANNEL_TYPE_ANGLE
+TEST(RCInputTest, set_control_in_angle)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    // for angle type channels, trim is expected to be near (pwm_max-pwm_min)/2
+    int16_t trim = 1533;
+
+    int16_t high_in = (pwm_max - pwm_min) / 2;
+    // sets high_in
+    chan.set_angle(high_in);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+
+    /* test RC_CHANNEL_TYPE_ANGLE
+     * control_in maps (reversed = false):
+     * [pwm_min, trim-dz] to [-high_in, 0]
+     * [trim-dz, trim+dz] to zero
+     * [trim+dz, pwm_max] to [0, high_in]
+     *
+     * control_in maps (reversed = true):
+     * [pwm_min, trim-dz] to [high_in, 0]
+     * [trim-dz, trim+dz] to zero
+     * [trim+dz, pwm_max] to [0, -high_in]
+     */
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d\n", reversed);
+        // test over the control_in range [-high_in, high_in]
+        for (int16_t c_in=-high_in; c_in<=high_in; c_in+=10) {
+            chan.set_control_in(c_in);
+            // norm_in should range [-1, 1]
+            float n_in = chan.norm_input();
+
+            // to compare normalized value to control_in value
+            // map n_in [-1, 1] to control_in [-high_in, high_in]
+            int16_t tc_in = round(n_in * high_in);
+            DEBUG_PRINTF("control_in: %4i, tc_in: %4i, pwm: %4i, norm_input: %10.7f\n", c_in, tc_in, chan.angle_to_pwm_no_dz(c_in), n_in);
+
+            EXPECT_NEAR(c_in, tc_in, 1);
+            EXPECT_EQ(n_in, chan.norm_input_dz());
+        }
+    } while (!reversed);
+
+}
+
+// Verify that set_control_in() results in correct values for norm_in
+// for channels of type RC_CHANNEL_TYPE_RANGE
+TEST(RCInputTest, set_control_in_range)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    // for range type channels, trim is expected to be near pwm_min
+    int16_t trim = pwm_min;
+
+    int16_t high_in = (pwm_max - pwm_min);
+    // sets high_in
+    chan.set_range(high_in);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+
+    // test RC_CHANNEL_TYPE_RANGE
+    // control_in maps [pwm_min, pwm_max] to [0, high_in]
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d\n", reversed);
+        // test over the control_in range [0, high_in]
+        for (int16_t c_in=0; c_in<=high_in; c_in+=10) {
+            chan.set_control_in(c_in);
+            // norm_in should range [-1, 1]
+            float n_in = chan.norm_input();
+
+            // map n_in [-1, 1] to control_in [0, high_in]
+            // to compare normalized value to control_in value
+            int16_t tc_in = round(n_in * high_in);
+            DEBUG_PRINTF("control_in: %4i, tc_in: %4i, pwm: %4i, norm_input: %10.7f\n", c_in, tc_in, chan.range_to_pwm_no_dz(c_in), n_in);
+
+            EXPECT_NEAR(c_in, tc_in, 1);
+            EXPECT_EQ(n_in, chan.norm_input_dz());
+        }
+    } while (!reversed);
+
+}
+
+AP_GTEST_MAIN()

--- a/libraries/RC_Channel/tests/wscript
+++ b/libraries/RC_Channel/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap'
+    )


### PR DESCRIPTION
Currently, RC_Channel::set_control_in() sets an arbitrary value of control_in, breaking the (implicit) contract that control_in and norm_in both reflect the current value of radio_in.  This PR makes norm_in consistent with control_in (although both values then disagree with radio_in).  
Also, note that neither control_in nor norm_in is logged (only radio_in is logged), so use of set_control_in() is visible in logs only through its side effects and those will not be consistent with radio_in.

This change reduces the likelihood of bugs in new code which uses RC_Channel::norm_input().
With this change, it is not necessary to know whether set_control_in has been called on an RC_Channel in order to use norm_input().

Without this change, calls to norm_input will return values inconsistent with calls to get_control_in() after a call to set_control_in. 
and it is difficult to determine whether norm_input() is safe to use.

This PR also adds unit tests using source code from ArduPlane-stable (4.0.9) as the gold standard for the behaviour of norm_input() and other affected methods.  The unit tests also verify the consistency of norm_input with control_input.
