### PR TITLE
Pr cleanup norm input4

### DIFF
--- a/ArduPlane/Log.cpp
+++ b/ArduPlane/Log.cpp
@@ -382,6 +382,15 @@ const struct LogStructure Plane::log_structure[] = {
     { LOG_QTUN_MSG, sizeof(QuadPlane::log_QControl_Tuning),
       "QTUN", "QffffffeccffBB", "TimeUS,ThI,ABst,ThO,ThH,DAlt,Alt,BAlt,DCRt,CRt,TMix,Sscl,Trn,Ast", "s----mmmnn----", "F----00000-0--" },
 
+//@LoggerMessage: RCTL
+// @Description: RC_Channel control_in and norm_in override value
+// @Field: TimeUS: Time since system startup
+// @Field: c: channel number
+// @Field: ctl_in: control_in value
+// @Field: norm_in: norm_in value
+      { LOG_RCTL_MSG, sizeof(QuadPlane::log_RCTL),
+        "RCTL", "QBhf", "TimeUS,c,ctl_in,norm_in", "s#--", "F---"},
+
 // @LoggerMessage: PIQR,PIQP,PIQY,PIQA
 // @Description: QuadPlane Proportional/Integral/Derivative gain values for Roll/Pitch/Yaw/Z
 // @Field: TimeUS: Time since system startup

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -97,6 +97,7 @@ enum log_messages {
     LOG_CMDA_MSG,
     LOG_CMDS_MSG,
     LOG_CMDH_MSG,
+    LOG_RCTL_MSG,
 };
 
 #define MASK_LOG_ATTITUDE_FAST          (1<<0)

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -176,6 +176,14 @@ public:
         uint8_t  assist;
     };
 
+    struct PACKED log_RCTL {
+        LOG_PACKET_HEADER;
+        uint64_t time_us;
+        uint8_t  chan;
+        int16_t  ctl_in;
+        float    norm_in;
+    };
+
     MAV_TYPE get_mav_type(void) const;
 
     enum Q_ASSIST_STATE_ENUM {
@@ -288,6 +296,7 @@ private:
     bool should_relax(void);
     void motors_output(bool run_rate_controller = true);
     void Log_Write_QControl_Tuning();
+    void Log_Write_RCTL(RC_Channel &chan, uint8_t cnum);
     float landing_descent_rate_cms(float height_above_ground) const;
     
     // setup correct aux channels for frame class

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -110,6 +110,11 @@ RC_Channel::RC_Channel(void)
     AP_Param::setup_object_defaults(this, var_info);
 }
 
+void RC_Channel::set_radio_in(int16_t val) {
+     radio_in = val;
+     _update();
+}
+
 void RC_Channel::set_range(uint16_t high)
 {
     type_in = RC_CHANNEL_TYPE_RANGE;
@@ -132,6 +137,40 @@ bool RC_Channel::get_reverse(void) const
     return bool(reversed.get());
 }
 
+/* Override the control_in value.
+ * To avoid internal inconsistencies recompute related state variables to
+ * make them consistent with the new control_in value.
+ *
+ *  The side effects of this function will be overridden on the next call to update()
+ * so the caller must guarantee that this method is called after update() and before
+ * control_in and/or norm_in, etc. are used.
+ */
+void RC_Channel::set_control_in(int16_t val)
+{
+    control_override = true;
+    control_in = val;
+    control_in_no_dz = val;
+
+    norm_in = (float)control_in / high_in;
+    norm_in_no_dz = norm_in;
+}
+
+void RC_Channel::_update(){
+    // control_in and control_in_no_dz depend on channel type
+    if (type_in == RC_CHANNEL_TYPE_RANGE) {
+        control_in = pwm_to_range();
+        control_in_no_dz = pwm_to_range_dz(0);
+    } else {
+        // RC_CHANNEL_TYPE_ANGLE
+        control_in = pwm_to_angle();
+        control_in_no_dz = pwm_to_angle_dz(0);
+    }
+    // norm_in and norm_in_no_dz do not depend on channel type
+    norm_in = calc_normalized_input(radio_in, dead_zone);
+    norm_in_no_dz = calc_normalized_input(radio_in, 0);
+    control_override = false;
+}
+
 // read input from hal.rcin or overrides
 bool RC_Channel::update(void)
 {
@@ -143,14 +182,44 @@ bool RC_Channel::update(void)
         return false;
     }
 
-    if (type_in == RC_CHANNEL_TYPE_RANGE) {
-        control_in = pwm_to_range();
-    } else {
-        //RC_CHANNEL_TYPE_ANGLE
-        control_in = pwm_to_angle();
-    }
+    _update();
 
     return true;
+}
+
+/*
+ * Note that if parameter radio_min is not less than parameter radio_trim or
+ * radio_max is not greater than radio_trim the resultant normalized value is zero
+ * when radio_in is below or above radio_trim, respectively. This is reasonable
+ * since parameters radio_min/max are expected to reflect the actual range of radio_in.
+ */
+float RC_Channel::calc_normalized_input(int16_t pwm, int16_t dz){
+    int16_t reverse_mul = (reversed?-1:1);
+    // constrain trim to [radio_min, radio_max]
+    int16_t dz_min = MAX(radio_trim, radio_min) - dz;
+    int16_t dz_max = MIN(radio_trim, radio_max) + dz;
+    float result = 0;
+    if ((pwm < dz_min) && (dz_min > radio_min)) {
+        result = reverse_mul * (float)(pwm - dz_min) / (float)(dz_min - radio_min);
+    } else if ((pwm > dz_max) && (radio_max > dz_max)) {
+        result = reverse_mul * (float)(pwm - dz_max) / (float)(radio_max  - dz_max);
+    }
+    return constrain_float(result, -1.0f, 1.0f);
+}
+
+float RC_Channel::calc_normalized_input_ignore_trim(int16_t pwm){
+    float span = radio_max - radio_min;
+    float result = 0;
+    if (!reversed) {
+        if (pwm > radio_min) {
+            result = (pwm - radio_min) / span;
+        }
+    } else {
+        if (pwm < radio_max) {
+            result = (radio_max - pwm) / span;
+        }
+    }
+    return constrain_float(result, 0.0f, 1.0f);
 }
 
 // recompute control values with no deadzone
@@ -256,51 +325,6 @@ int16_t RC_Channel::pwm_to_range_dz(uint16_t _dead_zone) const
 int16_t RC_Channel::pwm_to_range() const
 {
     return pwm_to_range_dz(dead_zone);
-}
-
-
-int16_t RC_Channel::get_control_in_zero_dz(void) const
-{
-    if (type_in == RC_CHANNEL_TYPE_RANGE) {
-        return pwm_to_range_dz(0);
-    }
-    return pwm_to_angle_dz(0);
-}
-
-// ------------------------------------------
-
-float RC_Channel::norm_input() const
-{
-    float ret;
-    int16_t reverse_mul = (reversed?-1:1);
-    if (radio_in < radio_trim) {
-        if (radio_min >= radio_trim) {
-            return 0.0f;
-        }
-        ret = reverse_mul * (float)(radio_in - radio_trim) / (float)(radio_trim - radio_min);
-    } else {
-        if (radio_max <= radio_trim) {
-            return 0.0f;
-        }
-        ret = reverse_mul * (float)(radio_in - radio_trim) / (float)(radio_max  - radio_trim);
-    }
-    return constrain_float(ret, -1.0f, 1.0f);
-}
-
-float RC_Channel::norm_input_dz() const
-{
-    int16_t dz_min = radio_trim - dead_zone;
-    int16_t dz_max = radio_trim + dead_zone;
-    float ret;
-    int16_t reverse_mul = (reversed?-1:1);
-    if (radio_in < dz_min && dz_min > radio_min) {
-        ret = reverse_mul * (float)(radio_in - dz_min) / (float)(dz_min - radio_min);
-    } else if (radio_in > dz_max && radio_max > dz_max) {
-        ret = reverse_mul * (float)(radio_in - dz_max) / (float)(radio_max  - dz_max);
-    } else {
-        ret = 0;
-    }
-    return constrain_float(ret, -1.0f, 1.0f);
 }
 
 // return a normalised input for a channel, in range -1 to 1,

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -138,8 +138,7 @@ bool RC_Channel::get_reverse(void) const
 }
 
 /* Override the control_in value.
- * To avoid internal inconsistencies recompute related state variables to
- * make them consistent with the new control_in value.
+ * Recompute related state variables to make them consistent with the new control_in value.
  *
  *  The side effects of this function will be overridden on the next call to update()
  * so the caller must guarantee that this method is called after update() and before
@@ -168,7 +167,6 @@ void RC_Channel::_update(){
     // norm_in and norm_in_no_dz do not depend on channel type
     norm_in = calc_normalized_input(radio_in, dead_zone);
     norm_in_no_dz = calc_normalized_input(radio_in, 0);
-    control_override = false;
 }
 
 // read input from hal.rcin or overrides

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -34,7 +34,7 @@ public:
     // get the center stick position expressed as a control_in value
     int16_t     get_control_mid() const;
 
-    // read input from hal.rcin and update control_in and norm_in values
+    // read input from hal.rcin then update control_in and norm_in values
     bool        update(void);
     // update control_in and norm_in values
     void        _update();
@@ -101,6 +101,7 @@ public:
     ChannelType get_type(void) const { return type_in; }
 
     AP_Int16    option; // e.g. activate EPM gripper / enable fence
+    bool        control_override;
 
     // auxiliary switch support
     void init_aux();

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -14,6 +14,7 @@ class RC_Channel {
 public:
     friend class SRV_Channels;
     friend class RC_Channels;
+    friend class RC_Channel_Test;
     // Constructor
     RC_Channel(void);
 
@@ -33,8 +34,13 @@ public:
     // get the center stick position expressed as a control_in value
     int16_t     get_control_mid() const;
 
-    // read input from hal.rcin - create a control_in value
+    // read input from hal.rcin and update control_in and norm_in values
     bool        update(void);
+    // update control_in and norm_in values
+    void        _update();
+
+    float       calc_normalized_input(int16_t pwm, int16_t dz);
+    float       calc_normalized_input_ignore_trim(int16_t pwm);
     void        recompute_pwm_no_deadzone();
 
     // calculate an angle given dead_zone and trim. This is used by the quadplane code
@@ -43,11 +49,11 @@ public:
 
     // return a normalised input for a channel, in range -1 to 1,
     // centered around the channel trim. Ignore deadzone.
-    float       norm_input() const;
+    float       norm_input() const { return norm_in_no_dz; }
 
     // return a normalised input for a channel, in range -1 to 1,
     // centered around the channel trim. Take into account the deadzone
-    float       norm_input_dz() const;
+    float       norm_input_dz() const { return norm_in; }
 
     // return a normalised input for a channel, in range -1 to 1,
     // ignores trim and deadzone
@@ -63,10 +69,10 @@ public:
     bool       in_trim_dz() const;
 
     int16_t    get_radio_in() const { return radio_in;}
-    void       set_radio_in(int16_t val) {radio_in = val;}
+    void       set_radio_in(int16_t val);
 
     int16_t    get_control_in() const { return control_in;}
-    void       set_control_in(int16_t val) { control_in = val;}
+    void       set_control_in(int16_t val);
 
     void       clear_override();
     void       set_override(const uint16_t v, const uint32_t timestamp_ms);
@@ -75,7 +81,7 @@ public:
     int16_t    stick_mixing(const int16_t servo_in);
 
     // get control input with zero deadzone
-    int16_t    get_control_in_zero_dz(void) const;
+    int16_t    get_control_in_zero_dz(void) const { return control_in_no_dz; }
 
     int16_t    get_radio_min() const {return radio_min.get();}
     void       set_radio_min(int16_t val) { radio_min = val;}
@@ -314,6 +320,10 @@ private:
 
     // value generated from PWM normalised to configured scale
     int16_t    control_in;
+    int16_t    control_in_no_dz;
+
+    float      norm_in;
+    float      norm_in_no_dz;
 
     AP_Int16    radio_min;
     AP_Int16    radio_trim;

--- a/libraries/RC_Channel/tests/test_RC_input.cpp
+++ b/libraries/RC_Channel/tests/test_RC_input.cpp
@@ -1,0 +1,428 @@
+/*
+ *       Unit Tests for RC_Channel library.
+ *       Based on original example by Jason Short. 2010
+ */
+
+#include <AP_gtest.h>
+
+#include <AP_HAL/AP_HAL.h>
+#include <RC_Channel/RC_Channel.h>
+
+//#define DBGPRINT
+#ifdef DBGPRINT
+#define  DEBUG_PRINTF(fmt, ...)  printf(fmt, __VA_ARGS__);
+#else
+#define DEBUG_PRINTF(fmt, ...)    /* Do nothing */
+#endif
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+class RC_Channel_Test : public RC_Channel
+{
+public:
+    void set_reverse(bool v) { reversed.set(v); }
+    void set_dead_zone(uint16_t v) { dead_zone.set(v); }
+};
+
+class RC_Channels_Test : public RC_Channels
+{
+public:
+
+    RC_Channel_Test obj_channels[NUM_RC_CHANNELS];
+
+    RC_Channel_Test *channel(const uint8_t chan) override {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+
+protected:
+
+    int8_t flight_mode_channel_number() const override { return 5; }
+
+private:
+
+};
+
+#define RC_CHANNELS_SUBCLASS RC_Channels_Test
+#define RC_CHANNEL_SUBCLASS RC_Channel_Test
+
+#include <RC_Channel/RC_Channels_VarInfo.h>
+
+static RC_Channels_Test rc_channels;
+
+// Use source code from stable release of ArduPlane to define correct behavior
+class GoldStandard
+{
+public:
+    // copied from ArduPlane-stable (4.0.9)
+    static float norm_input(int16_t radio_min, int16_t radio_max,
+                                     int16_t radio_trim, int16_t radio_in, bool reversed)
+    {
+        float ret;
+        int16_t reverse_mul = (reversed?-1:1);
+        if (radio_in < radio_trim) {
+            if (radio_min >= radio_trim) {
+                return 0.0f;
+            }
+            ret = reverse_mul * (float)(radio_in - radio_trim) / (float)(radio_trim - radio_min);
+        } else {
+            if (radio_max <= radio_trim) {
+                return 0.0f;
+            }
+            ret = reverse_mul * (float)(radio_in - radio_trim) / (float)(radio_max  - radio_trim);
+        }
+        return constrain_float(ret, -1.0f, 1.0f);
+    }
+
+    static float norm_input_dz(int16_t dead_zone, int16_t radio_min, int16_t radio_max,
+                                        int16_t radio_trim, int16_t radio_in, bool reversed)
+    {
+        int16_t dz_min = radio_trim - dead_zone;
+        int16_t dz_max = radio_trim + dead_zone;
+        float ret;
+        int16_t reverse_mul = (reversed?-1:1);
+        if (radio_in < dz_min && dz_min > radio_min) {
+            ret = reverse_mul * (float)(radio_in - dz_min) / (float)(dz_min - radio_min);
+        } else if (radio_in > dz_max && radio_max > dz_max) {
+            ret = reverse_mul * (float)(radio_in - dz_max) / (float)(radio_max  - dz_max);
+        } else {
+            ret = 0;
+        }
+        return constrain_float(ret, -1.0f, 1.0f);
+    }
+
+    static int16_t pwm_to_angle_dz_trim(uint16_t _dead_zone, uint16_t _trim, int16_t radio_in,
+                                        int16_t radio_min, int16_t radio_max, int16_t high_in, bool reversed)
+    {
+        int16_t radio_trim_high = _trim + _dead_zone;
+        int16_t radio_trim_low  = _trim - _dead_zone;
+
+        int16_t reverse_mul = (reversed?-1:1);
+
+        // don't allow out of range values
+        int16_t r_in = constrain_int16(radio_in, radio_min, radio_max);
+
+        if (r_in > radio_trim_high && radio_max != radio_trim_high) {
+            return reverse_mul * ((int32_t)high_in * (int32_t)(r_in - radio_trim_high)) / (int32_t)(radio_max  - radio_trim_high);
+        } else if (r_in < radio_trim_low && radio_trim_low != radio_min) {
+            return reverse_mul * ((int32_t)high_in * (int32_t)(r_in - radio_trim_low)) / (int32_t)(radio_trim_low - radio_min);
+        } else {
+            return 0;
+        }
+    }
+
+    static int16_t pwm_to_range_dz(uint16_t _dead_zone, int16_t radio_in, int16_t radio_min,
+                                   int16_t radio_max, int16_t high_in, bool reversed)
+    {
+        int16_t r_in = constrain_int16(radio_in, radio_min, radio_max);
+
+        if (reversed) {
+            r_in = radio_max - (r_in - radio_min);
+        }
+
+        int16_t radio_trim_low  = radio_min + _dead_zone;
+
+        if (r_in > radio_trim_low) {
+            return (((int32_t)(high_in) * (int32_t)(r_in - radio_trim_low)) / (int32_t)(radio_max - radio_trim_low));
+        }
+        return 0;
+    }
+
+};
+
+const int16_t pwm_min = 900;
+const int16_t pwm_trim = 1500;
+const int16_t pwm_max = 2100;
+const uint16_t dead_zone = 30;
+const float accuracy = 1.0e-7f;
+
+// Test norm_input and norm_input_dz with set_radio_in(pwm)
+TEST(RCInputTest, norm_input_set_radio_in)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(pwm_trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+
+    float orig_norm_input;
+    float new_norm_input;
+    float orig_norm_input_dz;
+    float new_norm_input_dz;
+
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d, dead_zone: %d\n", reversed, dead_zone);
+        // compare with original norm_input over the pwm range [pwm_min, pwm_max]
+        for (int16_t pwm=pwm_min; pwm<=pwm_max; pwm+=1) {
+            orig_norm_input = GoldStandard::norm_input(pwm_min, pwm_max, pwm_trim, pwm, reversed);
+            orig_norm_input_dz = GoldStandard::norm_input_dz(dead_zone, pwm_min, pwm_max, pwm_trim, pwm, reversed);
+            chan.set_radio_in(pwm);
+            new_norm_input = chan.norm_input();
+            new_norm_input_dz = chan.norm_input_dz();
+            DEBUG_PRINTF("pwm: %4i, orig: %10.7f, new: %10.7f\n", pwm, orig_norm_input_dz, new_norm_input_dz);
+            EXPECT_NEAR(new_norm_input, orig_norm_input, accuracy);
+            EXPECT_NEAR(new_norm_input_dz, orig_norm_input_dz, accuracy);
+        }
+        // test out of range pwm inputs
+        float rmin = reversed ? 1 : -1;
+        float rmax = -rmin;
+        chan.set_radio_in(pwm_min - 100);
+        EXPECT_NEAR(chan.norm_input(), rmin, accuracy);
+        chan.set_radio_in(pwm_max + 100);
+        EXPECT_NEAR(chan.norm_input(), rmax, accuracy);
+
+        // test out of range trim values
+        chan.set_radio_in(pwm_min);
+        chan.set_radio_trim(pwm_min - 100);
+        EXPECT_NEAR(chan.norm_input(), rmin, accuracy);
+        chan.set_radio_trim(pwm_max + 100);
+        EXPECT_NEAR(chan.norm_input(), rmin, accuracy);
+
+        chan.set_radio_trim(pwm_min - 100);
+        chan.set_radio_in(pwm_max);
+        EXPECT_NEAR(chan.norm_input(), rmax, accuracy);
+        chan.set_radio_trim(pwm_max);
+        chan.set_radio_in(pwm_max + 100);
+        EXPECT_NEAR(chan.norm_input(), 0, accuracy);
+        chan.set_radio_trim(pwm_trim);
+    } while (!reversed);
+
+}
+
+// Test norm_input and norm_input_dz with set_override(pwm) followed by update()
+TEST(RCInputTest, norm_input_update)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(pwm_trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+
+    float orig_norm_input;
+    float new_norm_input;
+    float orig_norm_input_dz;
+    float new_norm_input_dz;
+
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d\n", reversed);
+        // compare with original norm_input over the pwm range [pwm_min, pwm_max]
+        for (int16_t pwm=pwm_min; pwm<=pwm_max; pwm+=1) {
+            orig_norm_input = GoldStandard::norm_input(pwm_min, pwm_max, pwm_trim, pwm, reversed);
+            orig_norm_input_dz = GoldStandard::norm_input_dz(dead_zone, pwm_min, pwm_max, pwm_trim, pwm, reversed);
+
+            chan.set_override(pwm, 0);
+            chan.update();
+            new_norm_input = chan.norm_input();
+            new_norm_input_dz = chan.norm_input_dz();
+            DEBUG_PRINTF("pwm: %4i, orig: %10.7f, new: %10.7f\n", pwm, orig_norm_input, new_norm_input);
+            EXPECT_NEAR(new_norm_input, orig_norm_input, accuracy);
+            EXPECT_NEAR(new_norm_input_dz, orig_norm_input_dz, accuracy);
+        }
+        // test out of range inputs
+        float rmin = reversed ? 1 : -1;
+        float rmax = -rmin;
+        chan.set_radio_in(pwm_min - 100);
+        EXPECT_NEAR(chan.norm_input_dz(), rmin, accuracy);
+        chan.set_radio_in(pwm_max + 100);
+        EXPECT_NEAR(chan.norm_input_dz(), rmax, accuracy);
+    } while (!reversed);
+}
+
+// Test control_input and control_input_no_dz with set_override(pwm) followed by update()
+// for RC_CHANNEL_TYPE_RANGE
+TEST(RCInputTest, control_input_range)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(pwm_trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+    int16_t high_in = 1000;
+    // sets high_in
+    chan.set_range(high_in);
+
+    // test RC_CHANNEL_TYPE_RANGE
+    // control_in maps [pwm_min, pwm_max] to [0, high_in]
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d\n", reversed);
+        // test over the pwm range [pwm_min, pwm_max]
+        for (int16_t pwm=pwm_min; pwm<=pwm_max; pwm+=1) {
+            int16_t tc_in = GoldStandard::pwm_to_range_dz(dead_zone, pwm, pwm_min, pwm_max, high_in, reversed);
+            int16_t tc_in_no_dz = GoldStandard::pwm_to_range_dz(0, pwm, pwm_min, pwm_max, high_in, reversed);
+            chan.set_override(pwm, 0);
+            chan.update();
+            int16_t c_in = chan.get_control_in();
+            int16_t c_in_no_dz = chan.get_control_in_zero_dz();
+            DEBUG_PRINTF("pwm: %4i, tc_in: %d, c_in: %d\n", pwm, tc_in, c_in);
+            EXPECT_EQ(c_in, tc_in);
+            EXPECT_EQ(c_in_no_dz, tc_in_no_dz);
+        }
+        // test out of range inputs
+        int16_t rmin = reversed ? high_in : 0;
+        int16_t rmax = high_in - rmin;
+        chan.set_radio_in(pwm_min - 100);
+        EXPECT_EQ(chan.get_control_in(), rmin);
+        chan.set_radio_in(pwm_max + 100);
+        EXPECT_EQ(chan.get_control_in(), rmax);
+    } while (!reversed);
+
+}
+
+// Test control_input and control_input_no_dz with set_override(pwm) followed by update()
+// for RC_CHANNEL_TYPE_ANGLE
+TEST(RCInputTest, control_input_angle)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    // for angle type channels, trim is expected to be near (pwm_max-pwm_min)/2
+    int16_t trim = 1533;
+
+    int16_t high_in = 4500;
+    // sets high_in
+    chan.set_angle(high_in);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+
+    // test RC_CHANNEL_TYPE_ANGLE
+    // control_in maps [pwm_min, pwm_max] to [-high_in, high_in]
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d\n", reversed);
+        // test over the pwm range [pwm_min, pwm_max]
+        for (int16_t pwm=pwm_min; pwm<=pwm_max; pwm+=1) {
+            int16_t tc_in = GoldStandard::pwm_to_angle_dz_trim(dead_zone, trim, pwm, pwm_min, pwm_max, high_in, reversed);
+            int16_t tc_in_no_dz = GoldStandard::pwm_to_angle_dz_trim(0, trim, pwm, pwm_min, pwm_max, high_in, reversed);
+            chan.set_override(pwm, 0);
+            chan.update();
+            int16_t c_in = chan.get_control_in();
+            int16_t c_in_no_dz = chan.get_control_in_zero_dz();
+            DEBUG_PRINTF("pwm: %4i, tc_in: %d, c_in: %d\n", pwm, tc_in, c_in);
+            EXPECT_EQ(c_in, tc_in);
+            EXPECT_EQ(c_in_no_dz, tc_in_no_dz);
+        }
+        // test out of range inputs
+        int16_t rmin = reversed ? high_in : -high_in;
+        int16_t rmax = -rmin;
+        chan.set_radio_in(pwm_min - 100);
+        EXPECT_EQ(chan.get_control_in(), rmin);
+        chan.set_radio_in(pwm_max + 100);
+        EXPECT_EQ(chan.get_control_in(), rmax);
+    } while (!reversed);
+
+}
+
+// Verify that set_control_in() results in correct values for norm_in
+// for channels of type RC_CHANNEL_TYPE_ANGLE
+TEST(RCInputTest, set_control_in_angle)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    // for angle type channels, trim is expected to be near (pwm_max-pwm_min)/2
+    int16_t trim = 1533;
+
+    int16_t high_in = (pwm_max - pwm_min) / 2;
+    // sets high_in
+    chan.set_angle(high_in);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+
+    /* test RC_CHANNEL_TYPE_ANGLE
+     * control_in maps (reversed = false):
+     * [pwm_min, trim-dz] to [-high_in, 0]
+     * [trim-dz, trim+dz] to zero
+     * [trim+dz, pwm_max] to [0, high_in]
+     *
+     * control_in maps (reversed = true):
+     * [pwm_min, trim-dz] to [high_in, 0]
+     * [trim-dz, trim+dz] to zero
+     * [trim+dz, pwm_max] to [0, -high_in]
+     */
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d\n", reversed);
+        // test over the control_in range [-high_in, high_in]
+        for (int16_t c_in=-high_in; c_in<=high_in; c_in+=10) {
+            chan.set_control_in(c_in);
+            // norm_in should range [-1, 1]
+            float n_in = chan.norm_input();
+
+            // to compare normalized value to control_in value
+            // map n_in [-1, 1] to control_in [-high_in, high_in]
+            int16_t tc_in = round(n_in * high_in);
+            DEBUG_PRINTF("control_in: %4i, tc_in: %4i, norm_input: %10.7f\n", c_in, tc_in, n_in);
+
+            EXPECT_NEAR(c_in, tc_in, 1);
+            EXPECT_NEAR(n_in, chan.norm_input_dz(), 1e-6);
+        }
+    } while (!reversed);
+
+}
+
+// Verify that set_control_in() results in correct values for norm_in
+// for channels of type RC_CHANNEL_TYPE_RANGE
+TEST(RCInputTest, set_control_in_range)
+{
+    RC_Channel_Test chan = *rc_channels.channel(CH_1);
+
+    // for range type channels, trim is expected to be near pwm_min
+    int16_t trim = pwm_min;
+
+    int16_t high_in = (pwm_max - pwm_min);
+    // sets high_in
+    chan.set_range(high_in);
+
+    chan.set_radio_min(pwm_min);
+    chan.set_radio_trim(trim);
+    chan.set_radio_max(pwm_max);
+    chan.set_dead_zone(dead_zone);
+
+    // test RC_CHANNEL_TYPE_RANGE
+    // control_in maps [pwm_min, pwm_max] to [0, high_in]
+    bool reversed = true;
+    do {
+        reversed = !reversed;
+        chan.set_reverse(reversed);
+        DEBUG_PRINTF("reversed: %d\n", reversed);
+        // test over the control_in range [0, high_in]
+        for (int16_t c_in=0; c_in<=high_in; c_in+=10) {
+            chan.set_control_in(c_in);
+            // norm_in should range [-1, 1]
+            float n_in = chan.norm_input();
+
+            // map n_in [-1, 1] to control_in [0, high_in]
+            // to compare normalized value to control_in value
+            int16_t tc_in = round(n_in * high_in);
+            DEBUG_PRINTF("control_in: %4i, tc_in: %4i, norm_input: %10.7f\n", c_in, tc_in, n_in);
+
+            EXPECT_NEAR(c_in, tc_in, 1);
+            EXPECT_NEAR(n_in, chan.norm_input_dz(), 1e-6);
+        }
+    } while (!reversed);
+
+}
+
+AP_GTEST_MAIN()

--- a/libraries/RC_Channel/tests/wscript
+++ b/libraries/RC_Channel/tests/wscript
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap'
+    )


### PR DESCRIPTION
Class RC_Channel maintains state variable control_in as the most recent value of radio_in converted to either a RANGE or an ANGLE depending on state variables type_in and high_in and RC_Channel parameters min, max, trim and dz.

State variable control_in is updated only by RC_Channel::update() which is typically called by vehicle code at 50Hz, with the notable exception that there is a public method RC_Channel::set_control_in which is called from 3 places: Copter::update_simple_mode, Plane::control_failsafe and QuadPlane::tailsitter_check_input.

It is not possible to eliminate set_control_in without providing the equivalent functionality elsewhere. In general, that functionality provides a mixing function from radio inputs to control inputs.  Simple mode rotates the roll and pitch axes so that the pitch axis always points "away from home".  tailsitter_check_input rotates the roll and yaw axes by 90 degrees around the body-frame pitch axis if "plane" type is selected.  The current implementation provides this capability by changing conrol_in values in place, with the downside being that these alterations to radio inputs are not clearly identified or logged.

One way to improve this would be to explicitly define a mixer to map radio_in to control_in values for every channel. This would change the update function to first get radio_in for all channels, then run a dynamic mixing function to generate control_in for all channels.  In this scenario, set_control_in would alter the mixing function instead of being invoked on a per-channel basis.
The remaining ambiguity is control_in vs. norm_in: these values differ in behaviour for TYPE and RANGE channels; unfortunately, channel type is not visible to users and varies on a per-vehicle basis.

RC_Channel also has methods get_control_in_zero_dz, norm_input and others which are called at 300 or 400 Hz in copter, plane and quadplane, recomputing values based on radio_in. Since radio_in updates at 50Hz, this wastes cpu cycles. 

norm_input (and relatives) are also inconsistent with the concept of channel "type" since these methods ignore control_in and, more importantly, use of method set_control_in has no effect on the behaviour of these methods. This has resulted in some confusion and the introduction of a bug in the tailsitter code.

This PR proposes unconditionally computing all values derived from radio_in in RC_Channel::update(). This should have minimal cpu impact since the 3 potentially unused results are only computed at 50Hz.

Also note that get_control_in() applies the deadzone but norm_input() does not.  This is made more explicit (in the code) by naming the new state variables control_in_no_dz and norm_in/norm_in_no_dz.  norm_input returns norm_in_no_dz (no change in behaviour) and norm_input_dz returns norm_in (also no change in behaviour).

Pros: 
- reduction in frequency of recomputation of norm_input
- set_control_in is less unsafe
- adds logging of modified control_in values when set_control_in is in use

Cons:
- RAM and CPU penalty: adds new state variables to class RC_Channel and recomputes them in update()
- Flash size: increases flash usage

TODO:
- I'd recommend adding notes to the developer wiki explaining the differences in behaviour between control_in and norm_in.
- Another source of potential confusion is that RCn_TRIM has no effect on range type channels when control_in is used, but this is not true if norm_input is used. A user does not know whether a channel is configured as range or angle, or whether the code uses control_in or norm_input, unless this information is provided in the wiki on a per-vehicle basis.

