### PR TITLE
add RC input mixer

### DIFF
--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -32,7 +32,7 @@ void Copter::arm_motors_check()
         return;
     }
 
-    int16_t yaw_in = channel_yaw->get_control_in();
+    int16_t yaw_in = channel_yaw->pwm_to_angle();
 
     // full right
     if (yaw_in > 4000) {

--- a/ArduPlane/radio.cpp
+++ b/ArduPlane/radio.cpp
@@ -119,7 +119,7 @@ void Plane::rudder_arm_disarm_check()
 {
 	if (!arming.is_armed()) {
 		// when not armed, full right rudder starts arming counter
-		if (channel_rudder->get_control_in() > 4000) {
+		if (channel_rudder->pwm_to_angle() > 4000) {
 			uint32_t now = millis();
 
 			if (rudder_arm_timer == 0 ||
@@ -139,7 +139,7 @@ void Plane::rudder_arm_disarm_check()
 		}
 	} else {
 		// full left rudder starts disarming counter
-		if (channel_rudder->get_control_in() < -4000) {
+		if (channel_rudder->pwm_to_angle() < -4000) {
 			uint32_t now = millis();
 
 			if (rudder_arm_timer == 0 ||

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -303,16 +303,27 @@ bool QuadPlane::tailsitter_transition_vtol_complete(void) const
 // handle different tailsitter input types
 void QuadPlane::tailsitter_check_input(void)
 {
-    if (tailsitter_active() &&
-        (tailsitter.input_type & TAILSITTER_INPUT_PLANE)) {
-        // the user has asked for body frame controls when tailsitter
-        // is active. We switch around the control_in value for the
-        // channels to do this, as that ensures the value is
-        // consistent throughout the code
-        int16_t roll_in = plane.channel_roll->get_control_in();
-        int16_t yaw_in = plane.channel_rudder->get_control_in();
-        plane.channel_roll->set_control_in(yaw_in);
-        plane.channel_rudder->set_control_in(-roll_in);
+    if (tailsitter_active()) {
+        if (tailsitter.input_type & TAILSITTER_INPUT_PLANE) {
+            // the user has asked for body frame controls when tailsitter
+            // is active. We switch around the control_in value for the
+            // channels to do this, as that ensures the value is
+            // consistent throughout the code
+            // create mixers for roll and rudder channels if necessary
+            RC_Channel *inputs[1];
+            float weights[1];
+
+            inputs[0] = plane.channel_rudder;
+            weights[0] = 1;
+            plane.channel_roll->update_mixer(plane.channel_roll, 1, inputs, weights);
+
+            inputs[0] = plane.channel_roll;
+            weights[0] = -1;
+            plane.channel_rudder->update_mixer(plane.channel_rudder, 1, inputs, weights);
+        } else {
+            plane.channel_roll->disable_mixer();
+            plane.channel_rudder->disable_mixer();
+        }
     }
 }
 

--- a/Rover/radio.cpp
+++ b/Rover/radio.cpp
@@ -86,7 +86,7 @@ void Rover::rudder_arm_disarm_check()
 
     if (!arming.is_armed()) {
         // when not armed, full right rudder starts arming counter
-        if (channel_steer->get_control_in() > 4000) {
+        if (channel_steer->pwm_to_angle() > 4000) {
             const uint32_t now = millis();
 
             if (rudder_arm_timer == 0 ||
@@ -105,7 +105,7 @@ void Rover::rudder_arm_disarm_check()
         }
     } else if ((arming_rudder == AP_Arming::RudderArming::ARMDISARM) && !g2.motors.active()) {
         // when armed and motor not active (not moving), full left rudder starts disarming counter
-        if (channel_steer->get_control_in() < -4000) {
+        if (channel_steer->pwm_to_angle() < -4000) {
             const uint32_t now = millis();
 
             if (rudder_arm_timer == 0 ||

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -259,6 +259,29 @@ int16_t RC_Channel::pwm_to_range() const
     return pwm_to_range_dz(dead_zone);
 }
 
+void RC_Channel::update_mixer(RC_Channel *c, uint8_t num_inputs, RC_Channel **in, float *w)
+{
+    if (this->mixer == NULL) {
+        this->mixer = new Mixer(c, num_inputs, in, w);
+    } else {
+        this->mixer->update(num_inputs, in, w);
+    }
+}
+
+void RC_Channel::disable_mixer()
+{
+    if (this->mixer) {
+        this->mixer->update(0, NULL, NULL);
+    }
+}
+
+int16_t RC_Channel::get_control_in() const
+{
+    if (this->mixer) {
+        return this->mixer->get_output();
+    }
+    return control_in;
+}
 
 int16_t RC_Channel::get_control_in_zero_dz(void) const
 {


### PR DESCRIPTION
Adds class RC_Channel::Mixer with the capability of mixing N channels together.  This provides an alternative to the current approach of calling set_control_in outside of RC_Channel, but it does not currently eliminate the resulting discrepancy in the behaviour of norm_input. norm_input() could also be modified to also use the MIxer if it has been defined.

If the mixer is instantiated and not disabled, get_control_in() returns the mixer output, otherwise it returns channel.control_in as before. If 

Since the use of a mixer on the rudder channel would break rudder arming, the rudder arming logic is changed to use pwm_to_angle() instead of get_control_in().

Does not address the issue that only radio_in is logged: for tailsitters in "plane" input mode and copters in simple mode, the logged radio_in values for [rudder, aileron] (plane) and [roll, pitch] (copter simple mode) will not correlate correctly with the actual get_control_in values.  Logging the (active) mixer outputs in addition to radio_in would provide the missing info. 

Tested tailsitter and copter simplemode in RealFlight/SITL.